### PR TITLE
Change the representation of optimized list of operation and add folding.

### DIFF
--- a/core/CCBatch.mli
+++ b/core/CCBatch.mli
@@ -51,17 +51,11 @@ module type S = sig
   val length : (_,_) op -> int
   (** Number of intermediate structures needed to compute this operation *)
 
-  type optimization_level =
-    | OptimNone
-    | OptimBase
-    | OptimMergeFlatMap
+  val apply : ('a,'b) op -> 'a t -> 'b t
+  (** Apply the operation to the collection. *)
 
-  val optimize : ?level:optimization_level -> ('a,'b) op -> ('a,'b) op
-  (** Try to minimize the length of the operation *)
-
-  val apply : ?level:optimization_level -> ('a,'b) op -> 'a t -> 'b t
-  (** Apply the operation to the collection.
-      @param level the optimization level, default is [OptimBase] *)
+  val apply_width_fold : ('a, 'b) op -> ('c -> 'b -> 'c) -> 'c -> 'a t -> 'c
+  (** Apply the operation plus a fold to the collection. *)
 
   val apply' : 'a t -> ('a,'b) op -> 'b t
   (** Flip of {!apply} *)


### PR DESCRIPTION
After optimization, an operation is a list of flatmap and something at the end, so I changed it to be actually that. It makes the representation cleaner imho and migth be usefull for, let's say, implement a ParMap version.
We could merge flatmaps at the end, I'm not sure how usefull it is. Did you benched that ?

I also added folding.

I didn't updated benchmarks with the removal of the optimization level.
