### PR TITLE
CCOpt: add get_lazy convenience function

### DIFF
--- a/core/CCOpt.ml
+++ b/core/CCOpt.ml
@@ -104,6 +104,10 @@ let get_exn = function
   | Some x -> x
   | None -> invalid_arg "CCOpt.get_exn"
 
+let get_lazy default_fn x = match x with
+  | None -> default_fn ()
+  | Some y -> y
+
 let sequence_l l =
   let rec aux acc l = match l with
     | [] -> Some (List.rev acc)

--- a/core/CCOpt.mli
+++ b/core/CCOpt.mli
@@ -73,6 +73,10 @@ val get_exn : 'a t -> 'a
 (** Open the option, possibly failing if it is [None]
     @raise Invalid_argument if the option is [None] *)
 
+val get_lazy : (unit -> 'a) -> 'a t -> 'a
+(** [get_lazy default_fn x] unwraps [x], but if [x = None] it returns [default_fn ()] instead.
+    @since NEXT_RELEASE *)
+
 val sequence_l : 'a t list -> 'a list t
 (** [sequence_l [x1; x2; ...; xn]] returns [Some [y1;y2;...;yn]] if
     every [xi] is [Some yi]. Otherwise, if the list contains at least


### PR DESCRIPTION
A lazy version of get, for cases where creating the default value could be expensive.
