### PR TITLE
Elements in an LRU cache should be unique

### DIFF
--- a/src/data/CCCache.ml
+++ b/src/data/CCCache.ml
@@ -269,7 +269,7 @@ module LRU(X:HASH) = struct
   let set c x y =
     let len = H.length c.table in
     assert (len <= c.size);
-    if len = c.size
+    if len = c.size || H.mem c.table x
       then replace_ c x y
       else insert_ c x y
 


### PR DESCRIPTION
If it is not the case, the following code fails miserably:

```
let t = make 2
let () =
  set t 1 1;
  set t 1 1;
  set t 2 2;
  assert (get t 1 = 1)
```

because in that case the element returned by Hashtbl.find is *not* the
first bucket, which is the oldest one.