### PR TITLE
Update README.md test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ branch `stable` it is not necessary.
 
     $ make
 
-To build and run tests (requires `oUnit`, `qtest`, and `check`):
+To build and run tests (requires `oUnit`, `qtest`, and `qcheck`):
 
     $ opam install oUnit qtest qcheck
     $ ./configure --enable-tests

--- a/README.md
+++ b/README.md
@@ -182,16 +182,11 @@ branch `stable` it is not necessary.
 
     $ make
 
-To build and run tests (requires `oUnit` and `qtest`):
+To build and run tests (requires `oUnit`, `qtest`, and `check`):
 
-    $ opam install oUnit
-    $ make tests
-    $ ./tests.native
-
-and
-
-    $ opam install qtest
-    $ make qtest
+    $ opam install oUnit qtest qcheck
+    $ ./configure --enable-tests
+    $ make test
 
 To build the small benchmarking suite (requires `benchmark`):
 


### PR DESCRIPTION
The existing instructions did not work. I found that running `make tests` will tell you to do `ocaml setup.ml -configure --enable-tests` if you didn't before, but the instructions I changed it to works on master and seem more to the point than the warning given after running `make tests`.

In general I found it somewhat confusing on how I was supposed to enable the tests as there seems to be several ways to go about it. 