### PR TITLE
Uniform implementation for CCRandom.split_list

### DIFF
--- a/AUTHORS.adoc
+++ b/AUTHORS.adoc
@@ -12,3 +12,4 @@
 - Emmanuel Surleau (emm)
 - Guillaume Bury (guigui)
 - JP Rodi
+- octachron (Florian Angeletti)

--- a/src/core/CCRandom.ml
+++ b/src/core/CCRandom.ml
@@ -192,3 +192,31 @@ let (<*>) f g st = f st (g st)
 let __default_state = Random.State.make_self_init ()
 
 let run ?(st=__default_state) g = g st
+
+let uniformity_test ?(size_hint=10) k rng st =
+  let histogram = Hashtbl.create size_hint in
+  let add x = let n = try Hashtbl.find histogram x with Not_found -> 0 in
+    Hashtbl.replace histogram x (n + 1) in
+  let () =
+    for _i = 0 to ( k - 1 ) do
+      add @@ rng st
+    done in
+  let cardinal = float_of_int @@ Hashtbl.length histogram in
+  let kf = float_of_int k in
+  (* average number of points assuming an uniform distribution *)
+  let average = kf /. cardinal in
+  (* The number of points is a sum of random variables with binomial distribution *)
+  let p = 1. /. cardinal in
+  (* The variance of a binomial distribution with average p is *)
+  let variance = p *. (1. -. p ) in
+  (* Central limit theorem: a confidence interval of 4σ provides a false positive rate
+     of 0.00634% *)
+  let confidence = 4. in
+  let std = confidence *. ( sqrt @@ kf *. variance ) in
+  let predicate _key n acc =
+    acc && abs_float (average -. float_of_int n) < std in
+  Hashtbl.fold predicate histogram true
+
+(*$T split_list
+  run ( uniformity_test 50_000 (split_list 10 ~len:3) )
+*)

--- a/src/core/CCRandom.ml
+++ b/src/core/CCRandom.ml
@@ -100,11 +100,11 @@ let split i st =
     let j = 1 + Random.State.int st (i-1) in
     Some (j, i-j)
 
-let _diff_list l =
+let _diff_list ~last l =
   let rec diff_list acc = function
-    | [a;b] -> Some ( (b - a)::acc )
+    | [a] -> Some ( (last - a)::acc )
     | a::( b::_ as r ) -> diff_list ( (b-a)::acc ) r
-    | [_] | [] -> None
+    | [] -> None
   in
   diff_list [] l
 
@@ -118,8 +118,7 @@ let _diff_list l =
 let split_list i ~len st =
   if i >= len then
     let xs = sample_without_replacement (len-1) (int_range 1 @@ i-1) st in
-    let ordered_xs = List.sort compare (i::0::xs) in
-    _diff_list ordered_xs
+    _diff_list ( 0::xs ) ~last:i
   else
     None
 

--- a/src/core/CCRandom.ml
+++ b/src/core/CCRandom.ml
@@ -78,6 +78,20 @@ let replicate n g st =
     if n = 0 then acc else aux (g st :: acc) (n-1)
   in aux [] n
 
+(* Sample without replacement using rejection sampling. *)
+let sample_without_replacement (type elt)  ?(compare=compare) k (rng:elt t) st=
+  let module S = Set.Make(struct type t=elt let compare = compare end) in
+  let rec aux s k =
+    if k <= 0 then
+      S.elements s
+    else
+      let x = rng st in
+      if S.mem x s then
+        aux s k
+      else
+        aux (S.add x s) (k-1) in
+  aux S.empty k
+
 let list_seq l st = List.map (fun f -> f st) l
 
 exception SplitFail

--- a/src/core/CCRandom.mli
+++ b/src/core/CCRandom.mli
@@ -154,7 +154,7 @@ val (<*>) : ('a -> 'b) t -> 'a t -> 'b t
 val run : ?st:state -> 'a t -> 'a
 (** Using a random state (possibly the one in argument) run a generator *)
 
-(** {6 Random generator testing } *)
+(**/**)
 
 val uniformity_test : ?size_hint:int -> int -> 'a t -> bool t
 (** [uniformity_test k rng] tests the uniformity of the random generator [rng] using

--- a/src/core/CCRandom.mli
+++ b/src/core/CCRandom.mli
@@ -76,6 +76,14 @@ val replicate : int -> 'a t -> 'a list t
 (** [replicate n g] makes a list of [n] elements which are all generated
     randomly using [g] *)
 
+val sample_without_replacement:
+  ?compare:('a -> 'a -> int) -> int -> 'a t -> 'a list t
+(** [sample_without_replacement n g] makes a list of [n] elements which are all
+    generated randomly using [g] with the added constraint that none of the generated
+    random values are equal
+    @since 0.15
+ *)
+
 val list_seq : 'a t list -> 'a list t
 (** Build random lists from lists of random generators
     @since 0.4 *)

--- a/src/core/CCRandom.mli
+++ b/src/core/CCRandom.mli
@@ -153,3 +153,11 @@ val (<*>) : ('a -> 'b) t -> 'a t -> 'b t
 
 val run : ?st:state -> 'a t -> 'a
 (** Using a random state (possibly the one in argument) run a generator *)
+
+(** {6 Random generator testing } *)
+
+val uniformity_test : ?size_hint:int -> int -> 'a t -> bool t
+(** [uniformity_test k rng] tests the uniformity of the random generator [rng] using
+    [k] samples.
+    @since 0.15
+*)

--- a/src/core/CCRandom.mli
+++ b/src/core/CCRandom.mli
@@ -81,7 +81,7 @@ val sample_without_replacement:
 (** [sample_without_replacement n g] makes a list of [n] elements which are all
     generated randomly using [g] with the added constraint that none of the generated
     random values are equal
-    @since 0.15
+    @since NEXT_RELEASE
  *)
 
 val list_seq : 'a t list -> 'a list t
@@ -159,5 +159,5 @@ val run : ?st:state -> 'a t -> 'a
 val uniformity_test : ?size_hint:int -> int -> 'a t -> bool t
 (** [uniformity_test k rng] tests the uniformity of the random generator [rng] using
     [k] samples.
-    @since 0.15
+    @since NEXT_RELEASE
 *)


### PR DESCRIPTION
This pull request modifies the implementation of `CCRandom.split_list` to make the underlying distribution uniform. All tuples (x_1,..,x_n) satisfying the constraint ∑ x_k = i should now appear with the same probability.

To test this property, I have also added a statistical uniformity test. Like any statistical test, this test has a non-zero false positive rate; but these false positives should be quite rare with the confidence interval that I have chosen (every few years assuming one test by day). 

I have also added a `sample_without_rejection` function since it can be quite useful and was needed for the implementation of `split_list`. The current implementation use rejection sampling, which works well when the number of sample is small compared to the cardinal of the sampled set. 