### PR TITLE
join / both applicative functions for CCError

### DIFF
--- a/src/core/CCError.ml
+++ b/src/core/CCError.ml
@@ -162,6 +162,17 @@ let (<*>) f x = match f with
   | `Error s -> fail s
   | `Ok f -> map f x
 
+let join t = match t with
+  | `Ok (`Ok o) -> `Ok o
+  | `Ok (`Error e) -> `Error e
+  | (`Error _) as e -> e
+
+let both x y =
+  match x,y with
+   | `Ok o, `Ok o' -> `Ok (o, o')
+   | `Ok _, `Error e -> `Error e
+   | `Error e, _  -> `Error e
+
 (** {2 Collections} *)
 
 let map_l f l =

--- a/src/core/CCError.mli
+++ b/src/core/CCError.mli
@@ -141,7 +141,18 @@ val pure : 'a -> ('a, 'err) t
 val (<*>) : ('a -> 'b, 'err) t -> ('a, 'err) t -> ('b, 'err) t
 (** [a <*> b] evaluates [a] and [b], and, in case of success, returns
     [`Ok (a b)]. Otherwise, it fails, and the error of [a] is chosen
-    over the error of [b] if both fail *)
+    over the error of [b] if both fail. *)
+
+val join : (('a, 'err) t, 'err) t -> ('a, 'err) t
+(** [join t], in case of success, returns [`Ok o] from [`Ok (`Ok o)]. Otherwise,
+    it fails with [`Error e] where [e] is the unwrapped error of [t]. 
+    @since NEXT_RELEASE *)
+
+val both : ('a, 'err) t  -> ('b, 'err) t -> (('a * 'b), 'err) t
+(** [both a b], in case of success, returns [`Ok (o, o')] with the ok values
+    of [a] and [b]. Otherwise, it fails, and the error of [a] is chosen over the
+    error of [b] if both fail. 
+    @since NEXT_RELEASE *)
 
 (** {2 Infix}
 


### PR DESCRIPTION
```join``` and ```both``` are convenience functions which exist in Jane Street's version of ```Result``` and ```Or_error```- I thought they would also be nice to have in ``CCError`.
