### PR TITLE
Make CCPersistentHashtbl.S.merge more general.

### DIFF
--- a/AUTHORS.adoc
+++ b/AUTHORS.adoc
@@ -13,3 +13,4 @@
 - Guillaume Bury (guigui)
 - JP Rodi
 - octachron (Florian Angeletti)
+- Johannes Kloos

--- a/src/data/CCPersistentHashtbl.ml
+++ b/src/data/CCPersistentHashtbl.ml
@@ -89,8 +89,8 @@ module type S = sig
   (** Fresh copy of the table; the underlying structure is not shared
       anymore, so using both tables alternatively will be efficient *)
 
-  val merge : (key -> 'a option -> 'a option -> 'a option) ->
-              'a t -> 'a t -> 'a t
+  val merge : (key -> 'a option -> 'b option -> 'c option) ->
+              'a t -> 'b t -> 'c t
   (** Merge two tables together into a new table. The function's argument
       correspond to values associated with the key (if present); if the
       function returns [None] the key will not appear in the result. *)
@@ -576,7 +576,7 @@ module Make(H : HashedType) : S with type key = H.t = struct
         if mem t1 k then tbl
         else match f k None (Some v2) with
           | None -> tbl
-          | Some _ -> replace tbl k v2
+          | Some v' -> replace tbl k v'
       ) tbl t2
 
   (*$R

--- a/src/data/CCPersistentHashtbl.mli
+++ b/src/data/CCPersistentHashtbl.mli
@@ -96,8 +96,8 @@ module type S = sig
   (** Fresh copy of the table; the underlying structure is not shared
       anymore, so using both tables alternatively will be efficient *)
 
-  val merge : (key -> 'a option -> 'a option -> 'a option) ->
-              'a t -> 'a t -> 'a t
+  val merge : (key -> 'a option -> 'b option -> 'c option) ->
+              'a t -> 'b t -> 'c t
   (** Merge two tables together into a new table. The function's argument
       correspond to values associated with the key (if present); if the
       function returns [None] the key will not appear in the result. *)


### PR DESCRIPTION
This patch brings the merge function of CCPersistentHashtbl
in line with the merge functions of other maps
(Map, BatMap from batteries, CCWBTree). In particular, its signature
changes from the restrictive
```merge: (key -> 'a option -> 'a option -> 'a option) -> 'a t -> 'a t -> 'a t```
to a more general
```merge: (key -> 'a option -> 'b option -> 'c option) -> 'a t -> 'b t -> 'c t```
