### PR TITLE
show ocaml array type concretely in Make sig

### DIFF
--- a/src/data/CCRingBuffer.mli
+++ b/src/data/CCRingBuffer.mli
@@ -210,4 +210,4 @@ module Byte : S with module Array = Array.Byte
 module MakeFromArray(A : Array.S) : S with module Array = A
 
 (** Buffer using regular arrays *)
-module Make(X : sig type t end) : S with type Array.elt = X.t
+module Make(X : sig type t end) : S with type Array.elt = X.t and type Array.t = X.t array


### PR DESCRIPTION
A one line change to Make so that the OCaml array type is exposed as a standard OCaml array. Without this, the internal array module's type is opaque and thus not composable with any libraries which uses arrays of the same element type (in my case, floats). 

Example:

```OCaml
let arr:float array = let module RB = CCRingBuffer.Make(CCFloat) in RB.to_array (RB.create 0)
````

yields
```OCaml
Error: This expression has type RB.Array.t
but an expression was expected of type float array 
```

With the fix, though:
```OCaml
val arr : float array = [||]
```

(opposed to the opaque type ```RB.Array.t``` as it is in master)

Edit: formatting
 