### PR TITLE
Fixes map_or

### DIFF
--- a/src/core/CCResult.mli
+++ b/src/core/CCResult.mli
@@ -67,7 +67,7 @@ val get_exn : ('a, _) t -> 'a
 val get_or : ('a, _) t -> default:'a -> 'a
 (** [get_or e ~default] returns [x] if [e = Ok x], [default] otherwise *)
 
-val map_or : ('a -> 'b) ->  ('a, 'b) t -> default:'b -> 'b
+val map_or : ('a -> 'b) ->  ('a, 'c) t -> default:'b -> 'b
 (** [map_or f e ~default] returns [f x] if [e = Ok x], [default] otherwise *)
 
 val catch : ('a, 'err) t -> ok:('a -> 'b) -> err:('err -> 'b) -> 'b


### PR DESCRIPTION
~default arg for `map_or`, as well as function, should not depend on the type of error case.