### PR TITLE
threads/CCLock: add try_with_lock to wrap Mutex.try_lock

### DIFF
--- a/src/threads/CCLock.ml
+++ b/src/threads/CCLock.ml
@@ -35,6 +35,18 @@ let with_lock l f =
   assert_equal 10 (get l)
 *)
 
+let try_with_lock l f =
+  if Mutex.try_lock l.mutex
+  then
+    try
+      let x = f l.content in
+      Mutex.unlock l.mutex;
+      Some x
+    with e ->
+      Mutex.unlock l.mutex;
+      raise e
+  else None
+
 module LockRef = struct
   type 'a t = 'a lock
   let get t = t.content

--- a/src/threads/CCLock.mli
+++ b/src/threads/CCLock.mli
@@ -18,6 +18,12 @@ val with_lock : 'a t -> ('a -> 'b) -> 'b
     the lock [l], in a critical section. If [f x] fails, [with_lock l f]
     fails too but the lock is released *)
 
+val try_with_lock : 'a t -> ('a -> 'b) -> 'b option
+(** [try_with_lock l f] runs [f x] in a critical section if [l] is not
+    locked. [x] is the value protected by the lock [l]. If [f x]
+    fails, [try_with_lock l f] fails too but the lock is released
+    @since NEXT_RELEASE *)
+
 (** Type allowing to manipulate the lock as a reference
     @since 0.13 *)
 module LockRef : sig
@@ -48,7 +54,8 @@ val mutex : _ t -> Mutex.t
 (** Underlying mutex *)
 
 val get : 'a t -> 'a
-(** Get the value in the lock. The value that is returned isn't protected! *)
+(** Atomically get the value in the lock. The value that is returned
+    isn't protected! *)
 
 val set : 'a t -> 'a -> unit
 (** Atomically set the value


### PR DESCRIPTION
I've added `CCLock.try_with_lock` as I've found it useful when attempting to access one of many locked resources without blocking. There is no other way that I've found to query the lockedness of a mutex and, if unlocked, acquire it atomically.

I've also updated the documentation for `get` as I initially thought it disregarded the mutex and enabled one to access the data directly. I had attempted to use this in conjunction with `CCLock.mutex` and `Mutex.try_lock` to work-around the lack of `CCLock.try_with_lock` however this caused a deadlock as the mutex had already been acquired when I called `get`.

I'm happy to work with you to get this functionality merged so let me know if there are changes you'd like to see.

Thanks!