### PR TITLE
Fix with_acquire: release a non locked mutex is UB

### DIFF
--- a/src/threads/CCSemaphore.ml
+++ b/src/threads/CCSemaphore.ml
@@ -53,14 +53,13 @@ let release m t =
 *)
 
 let with_acquire ~n t ~f =
-  Mutex.lock t.mutex;
-  acquire_once_locked_ n t;
+  acquire n t;
   try
     let x = f() in
-    release_once_locked_ n t;
+    release n t;
     x
   with e ->
-    release_once_locked_ n t;
+    release n t;
     raise e
 
 (*$R


### PR DESCRIPTION
This is segfaulting (on ubuntu 16.04 and 16.10) when trying to release the unlocked mutex in the release stage (in general this is an undefined behavior AFAIK).