### PR TITLE
Plugs some holes in CCOpt

### DIFF
--- a/AUTHORS.adoc
+++ b/AUTHORS.adoc
@@ -18,3 +18,4 @@
 - Roma Sokolov (@little-arhat)
 - Malcolm Matalka (`orbitz`)
 - David Sheets (@dsheets)
+- Glenn Slotte (glennsl)

--- a/src/core/CCOpt.ml
+++ b/src/core/CCOpt.ml
@@ -13,6 +13,10 @@ let map_or ~default f = function
   | None -> default
   | Some x -> f x
 
+let map_lazy default_fn f = function
+  | None -> default_fn ()
+  | Some x -> f x
+
 let is_some = function
   | None -> false
   | Some _ -> true
@@ -54,9 +58,15 @@ let (<*>) f x = match f, x with
 
 let (<$>) = map
 
-let (<+>) a b = match a with
-  | None -> b
+let or_ ~else_ a = match a with
+  | None -> else_
   | Some _ -> a
+
+let or_lazy ~else_ a = match a with
+  | None -> else_ ()
+  | Some _ -> a
+
+let (<+>) a b = or_ ~else_:b a
 
 let choice l = List.fold_left (<+>) None l
 
@@ -136,6 +146,18 @@ let to_list o = match o with
 let of_list = function
   | x::_ -> Some x
   | [] -> None
+
+let to_result err = function
+  | None -> Error err
+  | Some x -> Ok x
+
+let to_result_lazy err_fn = function
+  | None -> Error (err_fn ())
+  | Some x -> Ok x
+
+let of_result = function
+  | Error _ -> None
+  | Ok x -> Some x
 
 module Infix = struct
   let (>|=) = (>|=)

--- a/src/core/CCOpt.mli
+++ b/src/core/CCOpt.mli
@@ -9,8 +9,12 @@ val map : ('a -> 'b) -> 'a t -> 'b t
 (** Transform the element inside, if any *)
 
 val map_or : default:'b -> ('a -> 'b) -> 'a t -> 'b
-(** [map_or ~default f o] is [f x] if [o = Some x], [default otherwise]
+(** [map_or ~default f o] is [f x] if [o = Some x], [default] otherwise
     @since 0.16 *)
+
+val map_lazy : (unit -> 'b) -> ('a -> 'b) -> 'a t -> 'b
+(** [map_lazy default_fn f o] if [f o] if [o = Some x], [default_fn ()] otherwise 
+    @since NEXT_RELEASE *)
 
 val is_some : _ t -> bool
 
@@ -94,6 +98,14 @@ val (<$>) : ('a -> 'b) -> 'a t -> 'b t
 
 (** {2 Alternatives} *)
 
+val or_ : else_:('a t) -> 'a t -> 'a t
+(** [or_ ~else_ a] is [a] if [a] is [Some _], [else_] otherwise
+    @since NEXT_RELEASE *)
+
+val or_lazy : else_:(unit -> 'a t) -> 'a t -> 'a t
+(** [or_lazy else_ a] is [a] if [a] is [Some _], [else_ ()] otherwise
+    @since NEXT_RELEASE *)
+
 val (<+>) : 'a t -> 'a t -> 'a t
 (** [a <+> b] is [a] if [a] is [Some _], [b] otherwise *)
 
@@ -117,6 +129,15 @@ val to_list : 'a t -> 'a list
 
 val of_list : 'a list -> 'a t
 (** Head of list, or [None] *)
+
+val to_result : 'e -> 'a t -> ('a, 'e) Result.result
+(** @since NEXT_RELEASE *)
+
+val to_result_lazy : (unit -> 'e) -> 'a t -> ('a, 'e) Result.result
+(** @since NEXT_RELEASE *)
+
+val of_result : ('a, _) Result.result -> 'a t
+(** @since NEXT_RELEASE *)
 
 type 'a sequence = ('a -> unit) -> unit
 type 'a gen = unit -> 'a option


### PR DESCRIPTION
This adds the following functions to CCOpt:
* `map_lazy` -- for consistency with `get_lazy`
* `or_` -- as a named alternative to `<+>` and to allow `or_lazy`
* `or_lazy` -- for consistency with `get_lazy`
* `to_result` -- for consistency with other core type conversions
* `to_result_lazy` -- for consistency with `get_lazy`
* `of_result` -- for consistency with other core type conversions