### PR TITLE
Size tracking bitvector

### DIFF
--- a/AUTHORS.adoc
+++ b/AUTHORS.adoc
@@ -19,3 +19,4 @@
 - Malcolm Matalka (`orbitz`)
 - David Sheets (@dsheets)
 - Glenn Slotte (glennsl)
+- Leonid Rozenberg (@rleonid)

--- a/README.adoc
+++ b/README.adoc
@@ -23,7 +23,7 @@ Containers is:
 - A usable, reasonably well-designed library that extends OCaml's standard
   library (in 'src/core/', packaged under `containers` in ocamlfind. Modules
   are totally independent and are prefixed with `CC` (for "containers-core"
-  or "companion-cube" because I'm megalomaniac). This part should be
+  or "companion-cube" because I'm a megalomaniac). This part should be
   usable and should work. For instance, `CCList` contains functions and
   lists including safe versions of `map` and `append`. It also
   provides a drop-in replacement to the standard library, in the module

--- a/src/data/CCBV.ml
+++ b/src/data/CCBV.ml
@@ -451,6 +451,14 @@ let diff in_ not_in =
   diff_into ~into not_in;
   into
 
+(*$T
+  diff (of_list [1;2;3])    (of_list [1;2;3])   |> to_list = [];
+  diff (of_list [1;2;3])    (of_list [1;2;3;4]) |> to_list = [];
+  diff (of_list [1;2;3;4])  (of_list [1;2;3])   |> to_list = [4];
+  diff (of_list [1;2;3])      (of_list [1;2;3;400]) |> to_list = [];
+  diff (of_list [1;2;3;400])  (of_list [1;2;3])     |> to_list = [400];
+*)
+
 let select bv arr =
   let l = ref [] in
   begin try

--- a/src/data/CCBV.mli
+++ b/src/data/CCBV.mli
@@ -21,14 +21,19 @@ val copy : t -> t
 (** Copy of bitvector *)
 
 val cardinal : t -> int
-(** Number of bits set *)
+(** Number of set bits. *)
 
 val length : t -> int
-(** Length of underlying array *)
+(** Length of underlying bitvector. *)
+
+val capacity : t -> int
+(** The number of bits this bitvector can store without resizing. *)
 
 val resize : t -> int -> unit
-(** Resize the BV so that it has at least the given physical length
-    [resize bv n] should make [bv] able to store [(Sys.word_size - 2)* n] bits *)
+(** Resize the BV so that it has the specified length. This can grow or shrink
+    the underlying bitvector.
+
+    @raise Invalid_arg on negative sizes. *)
 
 val is_empty : t -> bool
 (** Any bit set? *)
@@ -62,7 +67,10 @@ val to_sorted_list : t -> int list
     increasing order *)
 
 val of_list : int list -> t
-(** From a list of true bits *)
+(** From a list of true bits.
+
+    The bits are interpreted as indices into the returned bitvector, so the final
+    bitvector will have [length t] equal to 1 more than max of list indices. *)
 
 val first : t -> int
 (** First set bit, or
@@ -72,17 +80,33 @@ val filter : t -> (int -> bool) -> unit
 (** [filter bv p] only keeps the true bits of [bv] whose [index]
     satisfies [p index] *)
 
+val negate_self : t -> unit
+(** [negate_self t] flips all of the bits in [t]. *)
+
+val negate : t -> t
+(** [negate t] returns a copy of [t] with all of the bits flipped. *)
+
 val union_into : into:t -> t -> unit
-(** [union ~into bv] sets [into] to the union of itself and [bv]. *)
+(** [union ~into bv] sets [into] to the union of itself and [bv].
+
+    Note that [into] will grow to accammodate the union. *)
 
 val inter_into : into:t -> t -> unit
-(** [inter ~into bv] sets [into] to the intersection of itself and [bv] *)
+(** [inter ~into bv] sets [into] to the intersection of itself and [bv]
+
+    Note that [into] will shrink to accammodate the union. *)
 
 val union : t -> t -> t
 (** [union bv1 bv2] returns the union of the two sets *)
 
 val inter : t -> t -> t
 (** [inter bv1 bv2] returns the intersection of the two sets *)
+
+val diff_into : into:t -> t -> unit
+(** [diff ~into t] Modify [into] with only the bits set but not in [t]. *)
+
+val diff : in_:t -> t -> t
+(** [diff ~in_ t] Return those bits found [in_] but not in [t]. *)
 
 val select : t -> 'a array -> 'a list
 (** [select arr bv] selects the elements of [arr] whose index

--- a/src/data/CCBV.mli
+++ b/src/data/CCBV.mli
@@ -3,9 +3,13 @@
 
 (** {2 Imperative Bitvectors}
 
-    The size of the bitvector is rounded up to the multiple of 30 or  62.
-    In other words some functions such as {!iter} might iterate on more
-    bits than what was originally asked for.
+    {b BREAKING CHANGES} since NEXT_RELEASE:
+    size is now stored along with the bitvector. Some functions have
+    a new signature.
+
+    The size of the bitvector used to be rounded up to the multiple of 30 or 62.
+    In other words some functions such as {!iter} would iterate on more
+    bits than what was originally asked for. This is not the case anymore.
 *)
 
 type t
@@ -21,13 +25,18 @@ val copy : t -> t
 (** Copy of bitvector *)
 
 val cardinal : t -> int
-(** Number of set bits. *)
+(** Number of bits set to one, seen as a set of bits. *)
 
 val length : t -> int
-(** Length of underlying bitvector. *)
+(** Size of underlying bitvector.
+    This is not related to the underlying implementation.
+    Changed at NEXT_RELEASE
+*)
 
 val capacity : t -> int
-(** The number of bits this bitvector can store without resizing. *)
+(** The number of bits this bitvector can store without resizing.
+
+    @since NEXT_RELEASE *)
 
 val resize : t -> int -> unit
 (** Resize the BV so that it has the specified length. This can grow or shrink
@@ -36,19 +45,19 @@ val resize : t -> int -> unit
     @raise Invalid_arg on negative sizes. *)
 
 val is_empty : t -> bool
-(** Any bit set? *)
+(** Are there any true bits? *)
 
 val set : t -> int -> unit
-(** Set i-th bit. *)
+(** Set i-th bit, extending the bitvector if needed. *)
 
 val get : t -> int -> bool
 (** Is the i-th bit true? Returns false if the index is too high*)
 
 val reset : t -> int -> unit
-(** Set i-th bit to 0 *)
+(** Set i-th bit to 0, extending the bitvector if needed. *)
 
 val flip : t -> int -> unit
-(** Flip i-th bit *)
+(** Flip i-th bit, extending the bitvector if needed. *)
 
 val clear : t -> unit
 (** Set every bit to 0 *)
@@ -72,16 +81,23 @@ val of_list : int list -> t
     The bits are interpreted as indices into the returned bitvector, so the final
     bitvector will have [length t] equal to 1 more than max of list indices. *)
 
-val first : t -> int
-(** First set bit, or
-    @raise Not_found if all bits are 0 *)
+val first : t -> int option
+(** First set bit, or return None.
+    changed type at NEXT_RELEASE *)
+
+val first_exn : t -> int
+ (** First set bit, or
+     @raise Not_found if all bits are 0
+     @since NEXT_RELEASE *)
 
 val filter : t -> (int -> bool) -> unit
 (** [filter bv p] only keeps the true bits of [bv] whose [index]
     satisfies [p index] *)
 
 val negate_self : t -> unit
-(** [negate_self t] flips all of the bits in [t]. *)
+(** [negate_self t] flips all of the bits in [t].
+
+    @since NEXT_RELEASE *)
 
 val negate : t -> t
 (** [negate t] returns a copy of [t] with all of the bits flipped. *)
@@ -89,12 +105,12 @@ val negate : t -> t
 val union_into : into:t -> t -> unit
 (** [union ~into bv] sets [into] to the union of itself and [bv].
 
-    Note that [into] will grow to accammodate the union. *)
+    Also updates the length of [into] to be at least [length bv]. *)
 
 val inter_into : into:t -> t -> unit
 (** [inter ~into bv] sets [into] to the intersection of itself and [bv]
 
-    Note that [into] will shrink to accammodate the union. *)
+    Also updates the length of [into] to be at most [length bv]. *)
 
 val union : t -> t -> t
 (** [union bv1 bv2] returns the union of the two sets *)
@@ -103,10 +119,14 @@ val inter : t -> t -> t
 (** [inter bv1 bv2] returns the intersection of the two sets *)
 
 val diff_into : into:t -> t -> unit
-(** [diff ~into t] Modify [into] with only the bits set but not in [t]. *)
+(** [diff ~into t] Modify [into] with only the bits set but not in [t].
 
-val diff : in_:t -> t -> t
-(** [diff ~in_ t] Return those bits found [in_] but not in [t]. *)
+    @since NEXT_RELEASE *)
+
+val diff : t -> t -> t
+(** [diff t1 t2] Return those bits found [t1] but not in [t2].
+
+    @since NEXT_RELEASE *)
 
 val select : t -> 'a array -> 'a list
 (** [select arr bv] selects the elements of [arr] whose index


### PR DESCRIPTION
A couple of notes:
- I didn't fully understand why the original representation used only 62 bits. I changed it to use 63. Maybe there was some confusion about the hamming distance/count bits code? But I believe that it also works for negative values.
- I changed slightly the behavior or `of_list`, `length` and `resize`.
- In general, the more that I worked on this the more that I'm puzzled about the actual usefulness of bitvectors that resize. I understand that it would be convenient, but for most use cases, the user is tracking a known set of states. In these cases I would imagine it an error for things to somewhat silently change size. It also leads to weird cases where `let i = 10000000 in get t i`  will succeed but then `set t i` might allocate a big chunk of memory. There could would seem more straight forward with fixed sizes and I'm tempted to use such a subset in my internal project.

Here are some micro benchmarks:

Creation

| Name     | Runs @ Samples | Time R^2 | Time/Run |            95ci | Cycls/Run | mWd/Run |
|---------:|---------------:|---------:|---------:|----------------:|----------:|--------:|
| Old:10   |    69757 @ 815 |     1.00 |   1.43us | -0.01us +0.01us |    4.28kc | 146.00w |
| Old:100  |     6517 @ 576 |     1.00 |  15.00us | -0.06us +0.07us |   45.01kc | 233.00w |
| Old:1000 |      582 @ 325 |     1.00 | 155.70us | -0.85us +1.13us |  467.09kc | 246.00w |
| New:10   |    74045 @ 821 |     1.00 |   1.35us | -0.01us +0.01us |    4.04kc |  74.00w |
| New:100  |     6582 @ 577 |     1.00 |  14.77us | -0.07us +0.08us |   44.32kc |  74.00w |
| New:1000 |      587 @ 326 |     1.00 | 155.06us | -0.73us +0.79us |  465.15kc |  74.00w |

Union

| Name     | Runs @ Samples | Time R^2 |     Time/Run |                95ci | Cycls/Run |    mWd/Run |
|---------:|---------------:|---------:|-------------:|--------------------:|----------:|-----------:|
| Old:10   |    83428 @ 833 |     0.98 |   1_202.80ns |   -30.65ns +51.24ns |    3.61kc |    619.00w |
| Old:100  |     7410 @ 589 |     0.98 |  13_180.18ns | -209.43ns +341.70ns |   39.54kc |  6_739.00w |
| Old:1000 |      686 @ 343 |     1.00 | 133_154.77ns | -405.34ns +415.45ns |  399.44kc | 67_939.00w |
| New:10   |   121743 @ 871 |     0.99 |     822.18ns |   -14.10ns +23.16ns |    2.47kc |    619.00w |
| New:100  |    10897 @ 628 |     0.99 |   9_041.62ns |  -88.02ns +106.60ns |   27.12kc |  6_739.00w |
| New:1000 |      987 @ 382 |     0.99 |  92_881.11ns | -639.35ns +855.09ns |  278.63kc | 67_939.00w |

Difference

| Name     | Runs @ Samples | Time R^2 |    Time/Run |                95ci |   Cycls/Run |     mWd/Run |
|---------:|---------------:|---------:|------------:|--------------------:|------------:|------------:|
| Old:10   |      324 @ 258 |     1.00 |    285.11us |     -1.11us +1.22us |    855.30kc |   1_276.01w |
| Old:100  |        81 @ 81 |     1.00 |  3_146.65us |   -24.91us +31.65us |  9_439.57kc |  13_966.00w |
| Old:1000 |        26 @ 26 |     1.00 | 31_455.14us | -151.50us +148.36us | 94_362.01kc | 140_866.00w |
| New:10   |    86814 @ 837 |     0.97 |      1.12us |     -0.01us +0.02us |      3.37kc |     619.00w |
| New:100  |     8020 @ 597 |     0.99 |     12.25us |     -0.21us +0.30us |     36.74kc |   6_739.00w |
| New:1000 |      746 @ 352 |     1.00 |    122.61us |     -0.60us +0.62us |    367.80kc |  67_939.00w |


Happy to discuss and document and test further.