### PR TITLE
Add CCCache.add

### DIFF
--- a/src/data/CCCache.ml
+++ b/src/data/CCCache.ml
@@ -30,6 +30,15 @@ type ('a, 'b) callback = in_cache:bool -> 'a -> 'b -> unit
 
 let clear c = c.clear ()
 
+let add c x y =
+  try
+    (* check that x is not bound (see invariants) *)
+    let _ = c.get x in
+    false
+  with Not_found ->
+    c.set x y;
+    true
+
 let default_callback_ ~in_cache:_ _ _ = ()
 
 let with_cache ?(cb=default_callback_) c f x =

--- a/src/data/CCCache.mli
+++ b/src/data/CCCache.mli
@@ -71,6 +71,11 @@ val size : (_,_) t -> int
 val iter : ('a,'b) t -> ('a -> 'b -> unit) -> unit
 (** Iterate on cached values. Should yield [size cache] pairs. *)
 
+val add : ('a, 'b) t -> 'a -> 'b -> bool
+(** Manually add a cached value. Returns [true] if the value has succesfully
+    been added, and [false] if the value was already bound.
+    @since NEXT_RELEASE *)
+
 val dummy : ('a,'b) t
 (** Dummy cache, never stores any value *)
 


### PR DESCRIPTION
# Purpose:
The purpose of this PR is to offer a way for user to manually add some values to a cache.

# Motivation:
One pattern that I often have in my code currently is to compute some kind of function (usually translation between ASTs) with a cache, but also allow to a posteriori fix some values for this function. Usually, the way it happens is I define the translation function, and then further in the code, extensions give some kind of semantics to certain values, which in this case means forcing the translation on some values. In case it seems surprising, all this forcing happens during the program initialization, so that the meaning of the translation does not change during execution. However, I find it a nice way to have a reasonably extensible translation function.

In any case, my goal could be achieved by using a lookup in another table in my cached function, but it seems a bit of waste to store the information at two places (in my "forced" table, and in the cache soon after), and a bit redundant. Hence this PR.

# Implementation:
The current implementation returns a boolean to notify whether the value has been succesfully added (it can fail if the value the user want to add is already bound). I thought about raising an exception in case it failed, but this way seemed cleaner.
Exposing this ability may break the semantics of a cache. However, so does using the same cache for two different functions, which actually suggests that it is already possible to forcefully add values to a cache, albeit with the quite ugly following code:

```ocaml
let add cache key value =
  let res = CCCache.with_cache cache (fun _ -> value) key in
  res = value (* replace with adequate equality function for cached values *)
```