### PR TITLE
Fix CCTrie.Make: Remove polymorphic comparison

### DIFF
--- a/src/data/CCTrie.ml
+++ b/src/data/CCTrie.ml
@@ -680,6 +680,21 @@ module Make(W : WORD)
       (T.below [1;1] t1 |> Sequence.to_list)
   *)
 
+  (* NOTE: Regression test. See #158 *)
+  (*$T
+    let module TPoly = Make (struct \
+        type t = (unit -> char) list \
+        type char_ = char \
+        let compare = compare \
+        let to_seq a k = List.iter (fun c -> k (c ())) a \
+        let of_list l = List.map (fun c -> (fun () -> c)) l \
+      end) \
+    in \
+    let trie = TPoly.of_list [[fun () -> 'a'], 1; [fun () -> 'b'], 2] in \
+    ignore (TPoly.below [fun () -> 'a'] trie |> Sequence.to_list); \
+    true
+  *)
+
   (*$Q & ~count:30
     Q.(list_of_size Gen.(0--100) (pair printable_string small_int)) (fun l -> \
       let t = S.of_list l in \

--- a/src/data/CCTrie.ml
+++ b/src/data/CCTrie.ml
@@ -593,6 +593,13 @@ module Make(W : WORD)
       in
       List.iter (explore ~dir k) l'
 
+  let _list_eq l1 l2 =
+    try List.for_all2 (fun x y -> W.compare x y = 0) l1 l2
+    with Invalid_argument _ -> false
+
+  let _key_to_list key =
+    List.rev (_seq_append_list_rev [] (W.to_seq key))
+
   (* range above (if [above = true]) or below a threshold .
      [p c c'] must return [true] if [c'], in the tree, meets some criterion
      w.r.t [c] which is a part of the key. *)
@@ -646,7 +653,7 @@ module Make(W : WORD)
           _iter_prefix ~prefix (fun key' v -> k (key', v)) t
         | Some (Node (Some v, _), prefix), Below ->
           (* yield the value for key *)
-          assert (W.of_list (prefix []) = key);
+          assert (_list_eq (prefix []) (_key_to_list key));
           k (key, v)
         | Some _, _
         | None, _ -> ()


### PR DESCRIPTION
Following #157, this PR fixes a fatal use of the polymorphic equality function in ```CCTrie```.