### PR TITLE
Allow negative indexes in CCList.remove_at_idx

### DIFF
--- a/src/core/CCList.ml
+++ b/src/core/CCList.ml
@@ -1111,12 +1111,19 @@ let remove_at_idx i l0 =
     | y::l' ->
       aux l' (y::acc) (i-1)
   in
-  aux l0 [] i
+  if i < 0 then
+    aux l0 [] (List.length l0 + i)
+  else
+    aux l0 [] i
 
 (*$T
   remove_at_idx 0 [1;2;3;4] = [2;3;4]
   remove_at_idx 3 [1;2;3;4] = [1;2;3]
   remove_at_idx 5 [1;2;3;4] = [1;2;3;4]
+  remove_at_idx (-1) [1;2;3;4] = [1;2;3]
+  remove_at_idx (-2) [1;2;3;4] = [1;2;4]
+  remove_at_idx (-3) [1;2;3;4] = [1;3;4]
+  remove_at_idx (-4) [1;2;3;4] = [2;3;4]
 *)
 
 let range_by ~step i j =

--- a/src/core/CCList.mli
+++ b/src/core/CCList.mli
@@ -359,7 +359,9 @@ val insert_at_idx : int -> 'a -> 'a t -> 'a t
 
 val remove_at_idx : int -> 'a t -> 'a t
 (** Remove element at given index. Does nothing if the index is
-    too high. *)
+    too high.
+    If the index is negative, it will remove element starting from the end
+    of the list. *)
 
 (** {2 Set Operators}
 


### PR DESCRIPTION
Implement suggestion by @bluddy: https://github.com/c-cube/ocaml-containers/pull/161#issuecomment-348809182

Do we want to do the same thing for every index-based functions ? (```insert_at_idx```, ```set_at_idx```, …)