### PR TITLE
CCRAL: Fixed bug in drop_tree_ / drop / take_drop

### DIFF
--- a/AUTHORS.adoc
+++ b/AUTHORS.adoc
@@ -25,3 +25,4 @@
 - Fabian Hemmer (copy)
 - Maciej Woś (@lostman)
 - Orbifx (Stavros Polymenis)
+- Rand (@rand00)

--- a/src/data/CCRAL.ml
+++ b/src/data/CCRAL.ml
@@ -337,7 +337,7 @@ and drop_tree_ ~size n t tail = match t with
   | Node (_,l,r) ->
     if n=1 then append_tree_ l (append_tree_ r tail)
     else
-      let size' = size/2 in
+      let size' = if size mod 2 <> 0 then (size/2)+1 else size/2 in
       if n-1 < size'
       then drop_tree_ ~size:size' (n-1) l (append_tree_ r tail)
       else drop_tree_ ~size:size' (n-1-size') r tail

--- a/src/data/CCRAL.ml
+++ b/src/data/CCRAL.ml
@@ -342,6 +342,10 @@ and drop_tree_ ~size n t tail = match t with
       then drop_tree_ ~size:size' (n-1) l (append_tree_ r tail)
       else drop_tree_ ~size:size' (n-1-size') r tail
 
+(*$T
+  of_list [1;2;3] |> drop 2 |> length = 1
+*)
+
 let drop_while ~f l =
   let rec aux p st = match st with
     | St_nil -> Nil


### PR DESCRIPTION
`drop_tree` drops everything when drop-count is equal length-1:
``` ocaml
# let l = CCRAL.(drop 2 @@ add_list empty [1;2;3]) ;;
val l : int L.t = <abstr>
# let _ = CCRAL.iter (Printf.printf "%d ") l ;;
- : unit = ()
```
This PR seems to do the right thing.
