### PR TITLE
Don't reverse twice in CCList.repeat

### DIFF
--- a/AUTHORS.adoc
+++ b/AUTHORS.adoc
@@ -25,3 +25,4 @@
 - Fabian Hemmer (copy)
 - Maciej Woś (@lostman)
 - Orbifx (Stavros Polymenis)
+- Dave Aitken (@actionshrimp)

--- a/src/core/CCList.ml
+++ b/src/core/CCList.ml
@@ -1253,11 +1253,15 @@ let replicate i x =
     else aux (x::acc) (i-1)
   in aux [] i
 
+
+(*$T
+  repeat 2 [1;2;3] = [1;2;3;1;2;3]
+*)
+
 let repeat i l =
-  let l' = List.rev l in
   let rec aux acc i =
     if i = 0 then List.rev acc
-    else aux (List.rev_append l' acc) (i-1)
+    else aux (List.rev_append l acc) (i-1)
   in aux [] i
 
 module Assoc = struct


### PR DESCRIPTION
Looks like the implementation of CCList.repeat reversed the list at the start and at the end - this adds a test and removes one of the reversals so the result comes out the right way round.