### PR TITLE
Add <|> to CCLazy_list

### DIFF
--- a/src/iter/CCLazy_list.ml
+++ b/src/iter/CCLazy_list.ml
@@ -82,9 +82,21 @@ let rec flat_map ~f l =
         Lazy.force res
   )
 
+let default b a =
+  lazy (
+      match a with
+      | lazy Nil -> Lazy.force b
+      | lazy a -> a
+    )
+
+(*$=
+  [1] (default (return 1) empty |> to_list)
+*)
+
 module Infix = struct
   let (>|=) x f = map ~f x
   let (>>=) x f = flat_map ~f x
+  let (<|>) = default
 end
 
 include Infix

--- a/src/iter/CCLazy_list.ml
+++ b/src/iter/CCLazy_list.ml
@@ -82,11 +82,11 @@ let rec flat_map ~f l =
         Lazy.force res
   )
 
-let default b a =
+let default ~default l =
   lazy (
-      match a with
-      | lazy Nil -> Lazy.force b
-      | lazy a -> a
+      match l with
+      | lazy Nil -> Lazy.force default
+      | lazy l -> l
     )
 
 (*$=
@@ -96,7 +96,7 @@ let default b a =
 module Infix = struct
   let (>|=) x f = map ~f x
   let (>>=) x f = flat_map ~f x
-  let (<|>) = default
+  let (<|>) a b = default ~default:b a
 end
 
 include Infix

--- a/src/iter/CCLazy_list.mli
+++ b/src/iter/CCLazy_list.mli
@@ -45,9 +45,14 @@ val append : 'a t -> 'a t -> 'a t
 val flat_map : f:('a -> 'b t) -> 'a t -> 'b t
 (** Monadic flatten + map. *)
 
+val default : 'a t -> 'a t -> 'a t
+(** Choice operator.
+    @since NEXT_RELEASE *)
+
 module Infix : sig
   val (>|=) : 'a t -> ('a -> 'b) -> 'b t
   val (>>=) : 'a t -> ('a -> 'b t) -> 'b t
+  val (<|>) : 'a t -> 'a t -> 'a t
 end
 
 include module type of Infix

--- a/src/iter/CCLazy_list.mli
+++ b/src/iter/CCLazy_list.mli
@@ -45,7 +45,7 @@ val append : 'a t -> 'a t -> 'a t
 val flat_map : f:('a -> 'b t) -> 'a t -> 'b t
 (** Monadic flatten + map. *)
 
-val default : 'a t -> 'a t -> 'a t
+val default : default:'a t -> 'a t -> 'a t
 (** Choice operator.
     @since NEXT_RELEASE *)
 


### PR DESCRIPTION
This little function is quite useful in practice

```ocaml
> to_list(default (return 1) (return 2));;
- : int list = [2]
> to_list(default (return 1) (empty));;
- : int list = [1]
```