### PR TITLE
Add optional transform function to CCLazy_list.of_list

### DIFF
--- a/src/iter/CCLazy_list.ml
+++ b/src/iter/CCLazy_list.ml
@@ -102,9 +102,9 @@ let rec of_gen g =
   Q.(list int) (fun l -> l = (Gen.of_list l |> of_gen |> to_list))
 *)
 
-let rec of_list = function
+let rec of_list ?(f = fun x -> x) = function
   | [] -> empty
-  | x :: tl -> cons x (of_list tl)
+  | x :: tl -> cons (f x) (of_list ~f tl)
 
 let to_list_rev l =
   let rec aux acc = function

--- a/src/iter/CCLazy_list.mli
+++ b/src/iter/CCLazy_list.mli
@@ -56,7 +56,7 @@ type 'a gen = unit -> 'a option
 
 val of_gen : 'a gen -> 'a t
 
-val of_list : 'a list -> 'a t
+val of_list : ?f:('a -> 'b) -> 'a list -> 'b t
 
 val to_list : 'a t -> 'a list
 


### PR DESCRIPTION
`of_list ~f x` is equivalent to `List.map f x |> of_list`, but in  a single pass