### PR TITLE
Comments - Style & typos fixing

### DIFF
--- a/src/core/CCChar.mli
+++ b/src/core/CCChar.mli
@@ -41,7 +41,7 @@ val to_int : t -> int
     @since 1.0 *)
 
 val pp_buf : Buffer.t -> t -> unit
-(** Used to be {!pp}, changed name @since 2.0 *)
+(** Renamed from [pp] since 2.0. *)
 
 val pp : Format.formatter -> t -> unit
-(** Used to be {!print}, changed name @since 2.0 *)
+(** Renamed from [print] since 2.0. *)

--- a/src/core/CCFormat.mli
+++ b/src/core/CCFormat.mli
@@ -56,7 +56,7 @@ val flush : unit printer
     @since 1.2 *)
 
 val string_quoted : string printer
-(** Like {!CCString.print}.
+(** Similar to {!CCString.print}.
     @since 0.14 *)
 
 val list : ?sep:unit printer -> 'a printer -> 'a list printer

--- a/src/core/CCFormat.mli
+++ b/src/core/CCFormat.mli
@@ -17,7 +17,8 @@ type 'a printer = t -> 'a -> unit
 
 (** {2 Combinators} *)
 
-val silent : 'a printer (** Prints nothing *)
+val silent : 'a printer
+(** Prints nothing. *)
 
 val unit : unit printer
 (** Prints "()". *)
@@ -55,7 +56,7 @@ val flush : unit printer
     @since 1.2 *)
 
 val string_quoted : string printer
-(** Similar to {!CCString.print}.
+(** Like {!CCString.print}.
     @since 0.14 *)
 
 val list : ?sep:unit printer -> 'a printer -> 'a list printer
@@ -65,8 +66,8 @@ val seq : ?sep:unit printer -> 'a printer -> 'a sequence printer
 
 val opt : 'a printer -> 'a option printer
 (** [opt pp] prints options as follows:
-    [Some x] will become "some foo" if [pp x ---> "foo"].
-    [None] will become "none". *)
+    - [Some x] will become "some foo" if [pp x ---> "foo"].
+    - [None] will become "none". *)
 
 (** In the tuple printers, the [sep] argument is only available.
     @since 0.17 *)
@@ -124,18 +125,18 @@ val const : 'a printer -> 'a -> unit printer
 
 val some : 'a printer -> 'a option printer
 (** [some pp] will print options as follows:
-    - [Some x] is printed using [pp] on [x].
-    - [None] is not printed at all.
+    - [Some x] is printed using [pp] on [x]
+    - [None] is not printed at all
     @since 1.0
 *)
 
 val lazy_force : 'a printer -> 'a lazy_t printer
-(** [lazy_force pp out x] forces [x] and prints the result with [pp]
+(** [lazy_force pp out x] forces [x] and prints the result with [pp].
     @since 2.0 *)
 
 val lazy_or : ?default:unit printer -> 'a printer -> 'a lazy_t printer
 (** [lazy_or ?default pp out x] prints [default] if [x] is not
-    evaluated yet, or uses [pp] otherwise
+    evaluated yet, or uses [pp] otherwise.
     @since 2.0 *)
 
 (** {2 ANSI codes}
@@ -191,28 +192,33 @@ val set_color_default : bool -> unit
 val with_color : string -> 'a printer -> 'a printer
 (** [with_color "Blue" pp] behaves like the printer [pp], but with the given
     style.
+
     {b status: unstable}
     @since 0.16 *)
 
 val with_colorf : string -> t -> ('a, t, unit, unit) format4 -> 'a
 (** [with_colorf "Blue" out "%s %d" "yolo" 42] will behave like {!Format.fprintf},
     but wrapping the content with the given style.
+
     {b status: unstable}
     @since 0.16 *)
 
 val with_color_sf : string -> ('a, t, unit, string) format4 -> 'a
 (** [with_color_sf "Blue" out "%s %d" "yolo" 42] will behave like
     {!sprintf}, but wrapping the content with the given style.
+
     Example:
     {[
       CCFormat.with_color_sf "red" "%a" CCFormat.Dump.(list int) [1;2;3] |> print_endline;;
     ]}
+
     {b status: unstable}
     @since 0.21 *)
 
 val with_color_ksf : f:(string -> 'b) -> string -> ('a, t, unit, 'b) format4 -> 'a
 (** [with_color_ksf "Blue" ~f "%s %d" "yolo" 42] will behave like
     {!ksprintf}, but wrapping the content with the given style.
+
     Example:
     the following with raise [Failure] with a colored message
     {[
@@ -244,14 +250,15 @@ val tee : t -> t -> t
 
 val sprintf : ('a, t, unit, string) format4 -> 'a
 (** Print into a string any format string that would usually be compatible
-    with {!fprintf}. Similar to {!Format.asprintf}. *)
+    with {!fprintf}. Like {!Format.asprintf}. *)
 
 val sprintf_no_color : ('a, t, unit, string) format4 -> 'a
-(** Similar to {!sprintf} but never prints colors.
+(** Like {!sprintf} but never prints colors.
     @since 0.16 *)
 
 val sprintf_dyn_color : colors:bool -> ('a, t, unit, string) format4 -> 'a
-(** Similar to {!sprintf} but enable/disable colors depending on [colors].
+(** Like {!sprintf} but enable/disable colors depending on [colors].
+    
     Example:
     {[
       (* with colors *)
@@ -269,7 +276,7 @@ val fprintf : t -> ('a, t, unit ) format -> 'a
     @since 0.14 *)
 
 val fprintf_dyn_color : colors:bool -> t -> ('a, t, unit ) format -> 'a
-(** Similar to {!fprintf} but enable/disable colors depending on [colors].
+(** Like {!fprintf} but enable/disable colors depending on [colors].
     @since 0.21 *)
 
 val ksprintf :

--- a/src/core/CCHashtbl.ml
+++ b/src/core/CCHashtbl.ml
@@ -205,7 +205,7 @@ module type S = sig
       @since 0.16 *)
 
   val of_seq_count : key sequence -> int t
-  (** Similar to {!add_seq_count}, but allocates a new table and returns it
+  (** Like {!add_seq_count}, but allocates a new table and returns it
       @since 0.16 *)
 
   val to_list : 'a t -> (key * 'a) list

--- a/src/core/CCHashtbl.mli
+++ b/src/core/CCHashtbl.mli
@@ -76,7 +76,7 @@ module Poly : sig
       @since 0.16 *)
 
   val of_seq_count : 'a sequence -> ('a, int) Hashtbl.t
-  (** Similar to {!add_seq_count}, but allocates a new table and returns it.
+  (** Like {!add_seq_count}, but allocates a new table and returns it.
       @since 0.16 *)
 
   val to_list : ('a,'b) Hashtbl.t -> ('a * 'b) list
@@ -106,8 +106,7 @@ module Poly : sig
   val pp : 'a printer -> 'b printer -> ('a, 'b) Hashtbl.t printer
   (** Printer for table.
       @since 0.13
-      Renamed from [print].
-      @since 2.0 *)
+      Renamed from [print] since 2.0. *)
 end
 
 include module type of Poly
@@ -178,7 +177,7 @@ module type S = sig
       @since 0.16 *)
 
   val of_seq_count : key sequence -> int t
-  (** Similar to {!add_seq_count}, but allocates a new table and returns it.
+  (** Like {!add_seq_count}, but allocates a new table and returns it.
       @since 0.16 *)
 
   val to_list : 'a t -> (key * 'a) list
@@ -208,8 +207,7 @@ module type S = sig
   val pp : key printer -> 'a printer -> 'a t printer
   (** Printer for tables.
       @since 0.13
-      Renamed from {!print}.
-      @since 2.0 *)
+      Renamed from [print] since 2.0. *)
 end
 
 module Make(X : Hashtbl.HashedType) :

--- a/src/core/CCHeap.ml
+++ b/src/core/CCHeap.ml
@@ -161,7 +161,7 @@ module type S = sig
   (** [of_list l] is [add_list empty l]. *)
 
   val add_seq : t -> elt sequence -> t
-  (** Similar to {!add_list}.
+  (** Like {!add_list}.
       @since 0.16 *)
 
   val of_seq : elt sequence -> t

--- a/src/core/CCHeap.mli
+++ b/src/core/CCHeap.mli
@@ -81,7 +81,7 @@ module type S = sig
   (** {2 Conversions}
 
       The interface of [of_gen], [of_seq], [of_klist]
-      has changed @since 0.16 (the old signatures
+      has changed since 0.16 (the old signatures
       are now [add_seq], [add_gen], [add_klist]). *)
 
   val to_list : t -> elt list
@@ -100,7 +100,7 @@ module type S = sig
   (** [of_list l] is [add_list empty l]. Complexity: [O(n log n)]. *)
 
   val add_seq : t -> elt sequence -> t (** @since 0.16 *)
-  (** Similar to {!add_list}. *)
+  (** Like {!add_list}. *)
 
   val of_seq : elt sequence -> t
   (** Build a heap from a given [sequence]. Complexity: [O(n log n)]. *)
@@ -133,7 +133,7 @@ module type S = sig
 
   val pp : ?sep:string -> elt printer -> t printer
   (** @since 0.16
-      Renamed from {!print} @since 2.0 *)
+      Renamed from {!print} since 2.0 *)
 end
 
 module Make(E : PARTIAL_ORD) : S with type elt = E.t

--- a/src/core/CCIO.mli
+++ b/src/core/CCIO.mli
@@ -83,7 +83,7 @@ val with_out : ?mode:int -> ?flags:open_flag list ->
 
 val with_out_a : ?mode:int -> ?flags:open_flag list ->
   string -> (out_channel -> 'a) -> 'a
-(** Similar to {!with_out} but with the [[Open_append; Open_creat; Open_wronly]]
+(** Like {!with_out} but with the [[Open_append; Open_creat; Open_wronly]]
     flags activated, to append to the file.
     @raise Sys_error in case of error (same as {!open_out} and {!close_out}). *)
 
@@ -196,7 +196,7 @@ module File : sig
   type walk_item = [`File | `Dir] * t
 
   val walk : t -> walk_item gen
-  (** Similar to {!read_dir} (with [recurse=true]), this function walks
+  (** Like {!read_dir} (with [recurse=true]), this function walks
       a directory recursively and yields either files or directories.
       Is a file anything that doesn't satisfy {!is_directory} (including
       symlinks, etc.)

--- a/src/core/CCInt64.mli
+++ b/src/core/CCInt64.mli
@@ -2,7 +2,7 @@
 
 (** {1 Int64}
 
-    Helpers for 64-bit integers.
+    Helpers for 64-bit integers
 
     @since 0.13 *)
 
@@ -114,8 +114,8 @@ val to_int : t -> int
     during the conversion. *)
 
 val of_int : int -> t
-(** Alias to {!Int64.of_int}
-    NOTE: used to return an option, but the function actually never fails *)
+(** Alias to {!Int64.of_int}.
+    NOTE: used to return an option, but the function actually never fails. *)
 
 val of_int_exn : int -> t
 (** Alias to {!Int64.of_int}.
@@ -128,11 +128,11 @@ val to_int32 : t -> int32
     during the conversion.  *)
 
 val of_int32 : int32 -> t
-(** Alias to {!Int64.of_int32}
+(** Alias to {!Int64.of_int32}.
     NOTE: use to return an option, but the function actually never fails. *)
 
 val of_int32_exn : int32 -> t
-(** Alias to {!Int64.of_int32}
+(** Alias to {!Int64.of_int32}.
     @deprecated since NEXT_RELEASE *)
 
 val to_nativeint : t -> nativeint
@@ -146,7 +146,7 @@ val of_nativeint : nativeint -> t
     NOTE: use to return an option, but the function actually never fails. *)
 
 val of_nativeint_exn : nativeint -> t
-(** Alias to {!Int64.of_nativeint}
+(** Alias to {!Int64.of_nativeint}.
     @deprecated since NEXT_RELEASE *)
 
 val to_float : t -> float
@@ -158,7 +158,7 @@ val of_float : float -> t
     discarding the fractional part (truncate towards 0).
     The result of the conversion is undefined if, after truncation,
     the number is outside the range \[{!CCInt64.min_int}, {!CCInt64.max_int}\].
-    NOTE: used to return an option, but the function never fails *)
+    NOTE: used to return an option, but the function never fails. *)
 
 val of_float_exn : float -> t
 (** Alias to {!Int64.of_float}.
@@ -171,7 +171,7 @@ val of_string : string -> t option
 (** Safe version of {!of_string_exn}. *)
 
 val of_string_opt : string -> t option
-(** Alias to {!of_string}
+(** Alias to {!of_string}.
     @since NEXT_RELEASE *)
 
 val of_string_exn : string -> t

--- a/src/core/CCList.mli
+++ b/src/core/CCList.mli
@@ -95,7 +95,7 @@ val init : int -> (int -> 'a) -> 'a t
     @since 0.6 *)
 
 val combine : 'a list -> 'b list -> ('a * 'b) list
-(** Similar to {!List.combine} but tail-recursive.
+(** Like {!List.combine} but tail-recursive.
     Transform a pair of lists into a list of pairs:
     [combine [a1; ...; an] [b1; ...; bn]] is
     [[(a1,b1); ...; (an,bn)]].

--- a/src/core/CCNativeint.mli
+++ b/src/core/CCNativeint.mli
@@ -2,7 +2,7 @@
 
 (** {1 Nativeint}
 
-    Helpers for processor-native integers.
+    Helpers for processor-native integers
 
     This module provides operations on the type [nativeint] of signed 32-bit integers 
     (on 32-bit platforms) or signed 64-bit integers (on 64-bit platforms). 

--- a/src/core/CCString.ml
+++ b/src/core/CCString.ml
@@ -44,7 +44,7 @@ module type S = sig
   val length : t -> int
 
   val blit : t -> int -> Bytes.t -> int -> int -> unit
-  (** Similar to {!String.blit}.
+  (** Like {!String.blit}.
       Compatible with the [-safe-string] option.
       @raise Invalid_argument if indices are not valid *)
 

--- a/src/core/CCString.mli
+++ b/src/core/CCString.mli
@@ -19,7 +19,7 @@ module type S = sig
   (** Return the length (number of characters) of the given string. *)
 
   val blit : t -> int -> Bytes.t -> int -> int -> unit
-  (** Similar to {!String.blit}.
+  (** Like {!String.blit}.
       Compatible with the [-safe-string] option.
       @raise Invalid_argument if indices are not valid. *)
 
@@ -38,25 +38,24 @@ module type S = sig
   (** {2 Conversions} *)
 
   val to_gen : t -> char gen
-  (** Return the [gen] of characters contained in the string *)
+  (** Return the [gen] of characters contained in the string. *)
 
   val to_seq : t -> char sequence
-  (** Return the [sequence] of characters contained in the string *)
+  (** Return the [sequence] of characters contained in the string. *)
 
   val to_klist : t -> char klist
-  (** Return the [klist] of characters contained in the string *)
+  (** Return the [klist] of characters contained in the string. *)
 
   val to_list : t -> char list
   (** Return the list of characters contained in the string. *)
 
   val pp_buf : Buffer.t -> t -> unit
-  (** Renamed from [pp].
-      @since 2.0 *)
+  (** Renamed from [pp] since 2.0. *)
 
   val pp : Format.formatter -> t -> unit
   (** Print the string within quotes.
-      Renamed from [print].
-      @since 2.0 *)
+
+      Renamed from [print] since 2.0. *)
 end
 
 (** {2 Strings} *)
@@ -75,7 +74,7 @@ val is_empty : string -> bool
 val hash : string -> int
 
 val init : int -> (int -> char) -> string
-(** Analog to [Array.init].
+(** Like [Array.init].
     @since 0.3.3 *)
 
 val rev : string -> string
@@ -127,7 +126,7 @@ val find_all_l : ?start:int -> sub:string -> string -> int list
     @since 0.17 *)
 
 val mem : ?start:int -> sub:string -> string -> bool
-(** [mem ~sub s] is true iff [sub] is a substring of [s].
+(** [mem ~sub s] is [true] iff [sub] is a substring of [s].
     @since 0.12 *)
 
 val rfind : sub:string -> string -> int
@@ -339,10 +338,10 @@ end
 module Split : sig
   (** Specification of what to do with empty blocks, as in [split ~by:"-" "-a-b-"].
 
-      - [{first=false; last=false}] will return [""; "a"; "b"; ""].
-      - [{first=true; last=false}] will return ["a"; "b" ""].
-      - [{first=false; last=true}] will return [""; "a"; "b"].
-      - [{first=true; last=true}] will return ["a"; "b"].
+      - [{first=false; last=false}] will return [""; "a"; "b"; ""]
+      - [{first=true; last=false}] will return ["a"; "b" ""]
+      - [{first=false; last=true}] will return [""; "a"; "b"]
+      - [{first=true; last=true}] will return ["a"; "b"]
 
       The default value of all remaining functions is [Drop_none].
       @since 1.5

--- a/src/core/CCUtf8_string.ml
+++ b/src/core/CCUtf8_string.ml
@@ -70,7 +70,7 @@ let next_ (type a) (st : Dec.t) ~(yield:uchar -> a) ~(stop:unit -> a) () : a =
     assert (n_bytes >= 1);
     (* is the string long enough to contain the whole codepoint? *)
     if st.i + n_bytes < st.len then (
-      aux 1 acc (* start with j=1, first char is already proccessed! *)
+      aux 1 acc (* start with j=1, first char is already processed! *)
     ) else (
       (* char is truncated *)
       malformed st;

--- a/src/core/CCUtf8_string.mli
+++ b/src/core/CCUtf8_string.mli
@@ -32,32 +32,32 @@ val compare : t -> t -> int
 val pp : Format.formatter -> t -> unit
 
 val to_string : t -> string
-(** Identity *)
+(** Identity. *)
 
 exception Malformed of string * int
 (** Malformed string at given offset *)
 
 val to_gen : ?idx:int -> t -> uchar gen
 (** Generator of unicode codepoints.
-    @param idx offset where to start the decoding *)
+    @param idx offset where to start the decoding. *)
 
 val to_seq : ?idx:int -> t -> uchar sequence
 (** Sequence of unicode codepoints.
-    @param idx offset where to start the decoding *)
+    @param idx offset where to start the decoding. *)
 
 val to_list : ?idx:int -> t -> uchar list
 (** List of unicode codepoints.
-    @param idx offset where to start the decoding *)
+    @param idx offset where to start the decoding. *)
 
 val fold : ?idx:int -> ('a -> uchar -> 'a) -> 'a -> t -> 'a
 
 val iter : ?idx:int -> (uchar -> unit) -> t -> unit
 
 val n_chars : t -> int
-(** Number of characters *)
+(** Number of characters. *)
 
 val n_bytes : t -> int
-(** Number of bytes *)
+(** Number of bytes. *)
 
 val map : (uchar -> uchar) -> t -> t
 
@@ -76,16 +76,16 @@ val of_gen : uchar gen -> t
 val of_list : uchar list -> t
 
 val of_string_exn : string -> t
-(** Validate string by checking it is valid UTF8
-    @raise Invalid_argument if the string is not valid UTF8 *)
+(** Validate string by checking it is valid UTF8.
+    @raise Invalid_argument if the string is not valid UTF8. *)
 
 val of_string : string -> t option
-(** Safe version of {!of_string_exn} *)
+(** Safe version of {!of_string_exn}. *)
 
 val is_valid : string -> bool
 (** Valid UTF8? *)
 
 val unsafe_of_string : string -> t
 (** Conversion from a string without validating.
-    Upon iteration, if an invalid substring is met, Malformed will be raised *)
+    Upon iteration, if an invalid substring is met, Malformed will be raised. *)
 

--- a/src/data/CCBV.mli
+++ b/src/data/CCBV.mli
@@ -51,7 +51,7 @@ val set : t -> int -> unit
 (** Set i-th bit, extending the bitvector if needed. *)
 
 val get : t -> int -> bool
-(** Is the i-th bit true? Returns false if the index is too high. *)
+(** Is the i-th bit true? Return false if the index is too high. *)
 
 val reset : t -> int -> unit
 (** Set i-th bit to 0, extending the bitvector if needed. *)
@@ -82,8 +82,8 @@ val of_list : int list -> t
     bitvector will have [length t] equal to 1 more than max of list indices. *)
 
 val first : t -> int option
-(** First set bit, or return None.
-    changed type at 1.2 *)
+(** First set bit, or return [None].
+    Changed type at 1.2 *)
 
 val first_exn : t -> int
 (** First set bit, or

--- a/src/data/CCCache.mli
+++ b/src/data/CCCache.mli
@@ -72,7 +72,7 @@ val iter : ('a,'b) t -> ('a -> 'b -> unit) -> unit
 (** Iterate on cached values. Should yield [size cache] pairs. *)
 
 val add : ('a, 'b) t -> 'a -> 'b -> bool
-(** Manually add a cached value. Returns [true] if the value has successfully
+(** Manually add a cached value. Return [true] if the value has successfully
     been added, and [false] if the value was already bound.
     @since 1.5 *)
 

--- a/src/data/CCDeque.mli
+++ b/src/data/CCDeque.mli
@@ -4,7 +4,7 @@
 (** {1 Imperative deque}
 
     This structure provides fast access to its front and back elements,
-    with O(1) operations *)
+    with O(1) operations. *)
 
 type 'a t
 (** Contains 'a elements, queue in both ways *)
@@ -79,7 +79,7 @@ type 'a sequence = ('a -> unit) -> unit
 
 val of_seq : 'a sequence -> 'a t
 (** Create a deque from the sequence.
-    optional argument [deque] disappears, use {!add_seq_back} instead since
+    Optional argument [deque] disappears, use {!add_seq_back} instead since
     0.13 *)
 
 val to_seq : 'a t -> 'a sequence
@@ -90,7 +90,7 @@ val of_gen : 'a gen -> 'a t
     @since 0.13 *)
 
 val to_gen : 'a t -> 'a gen
-(** Iterate on elements of the deque.
+(** Iterate on the elements of the deque.
     @since 0.13 *)
 
 val add_seq_front : 'a t -> 'a sequence -> unit

--- a/src/data/CCFun_vec.mli
+++ b/src/data/CCFun_vec.mli
@@ -62,7 +62,7 @@ val return : 'a -> 'a t
 val length : _ t -> int
 
 val push : 'a -> 'a t -> 'a t
-(** Add element at the end *)
+(** Add element at the end. *)
 
 val get : int -> 'a t -> 'a option
 
@@ -70,15 +70,15 @@ val get_exn : int -> 'a t -> 'a
 (** @raise Not_found if key not present. *)
 
 val pop_exn : 'a t -> 'a * 'a t
-(** Pop last element *)
+(** Pop last element. *)
 
 val iter : f:('a -> unit) -> 'a t -> unit
 
 val iteri : f:(int -> 'a -> unit) -> 'a t -> unit
-(** Iterate on elements with their index, in increasing order *)
+(** Iterate on elements with their index, in increasing order. *)
 
 val iteri_rev : f:(int -> 'a -> unit) -> 'a t -> unit
-(** Iterate on elements with their index, but starting from the end *)
+(** Iterate on elements with their index, but starting from the end. *)
 
 val fold : f:('b -> 'a -> 'b) -> x:'b -> 'a t -> 'b
 

--- a/src/data/CCGraph.mli
+++ b/src/data/CCGraph.mli
@@ -118,7 +118,7 @@ module Traverse : sig
     graph:('v, 'e) t ->
     'v sequence ->
     'v sequence_once
-  (** One-shot traversal of the graph using a tag set and the given bag *)
+  (** One-shot traversal of the graph using a tag set and the given bag. *)
 
   val dfs: tbl:'v set ->
     graph:('v, 'e) t ->
@@ -147,7 +147,7 @@ module Traverse : sig
     ('v * int * ('v,'e) path) sequence_once
   (** Dijkstra algorithm, traverses a graph in increasing distance order.
       Yields each vertex paired with its distance to the set of initial vertices
-      (the smallest distance needed to reach the node from the initial vertices)
+      (the smallest distance needed to reach the node from the initial vertices).
       @param dist distance from origin of the edge to destination,
         must be strictly positive. Default is 1 for every edge. *)
 

--- a/src/data/CCHet.mli
+++ b/src/data/CCHet.mli
@@ -1,7 +1,7 @@
 
 (* This file is free software, part of containers. See file "license" for more details. *)
 
-(** {1 Associative containers with Heterogenerous Values}
+(** {1 Associative containers with Heterogeneous Values}
 
     This is similar to {!CCMixtbl}, but the injection is directly used as
     a key.

--- a/src/data/CCMixset.mli
+++ b/src/data/CCMixset.mli
@@ -35,7 +35,7 @@ val newkey : unit -> 'a key
     Not thread-safe. *)
 
 val empty : t
-(** Empty set *)
+(** Empty set. *)
 
 val set : key:'a key -> 'a -> t -> t
 (** [set ~key v set] maps [key] to [v] in [set]. It means that

--- a/src/data/CCMultiMap.mli
+++ b/src/data/CCMultiMap.mli
@@ -52,7 +52,7 @@ module type S = sig
   (** Intersection of multimaps. *)
 
   val diff : t -> t -> t
-  (** Difference of maps, ie bindings of the first that are not
+  (** Difference of maps, i.e. bindings of the first that are not
       in the second. *)
 
   val equal : t -> t -> bool
@@ -62,7 +62,7 @@ module type S = sig
   (** Total order on multimaps. *)
 
   val submap : t -> t -> bool
-  (** [submap m1 m2] is true iff all bindings of [m1] are also in [m2]. *)
+  (** [submap m1 m2] is [true] iff all bindings of [m1] are also in [m2]. *)
 
   val to_seq : t -> (key * value) sequence
 

--- a/src/data/CCPersistentArray.mli
+++ b/src/data/CCPersistentArray.mli
@@ -63,14 +63,14 @@ val set  : 'a t -> int -> 'a -> 'a t
     range [0] to [Array.length a - 1]. *)
 
 val length : 'a t -> int
-(** Returns the length of the persistent array. *)
+(** Return the length of the persistent array. *)
 
 val copy : 'a t -> 'a t
 (** [copy a] returns a fresh copy of [a]. Both copies are independent. *)
 
 val map : ('a -> 'b) -> 'a t -> 'b t
 val mapi : (int -> 'a -> 'b) -> 'a t -> 'b t
-(** Applies the given function to all elements of the array, and returns
+(** Apply the given function to all elements of the array, and return
     a persistent array initialized by the results of f. In the case of [mapi],
     the function is also given the index of the element.
     It is equivalent to [fun f t -> init (fun i -> f (get t i))]. *)

--- a/src/data/CCRAL.mli
+++ b/src/data/CCRAL.mli
@@ -171,7 +171,7 @@ module Infix : sig
   (** Alias to {!map}. *)
 
   val (<*>) : ('a -> 'b) t -> 'a t -> 'b t
-  (** Alias to {!app} *)
+  (** Alias to {!app}. *)
 
   val (--) : int -> int -> int t
   (** Alias to {!range}. *)

--- a/src/data/CCRingBuffer.mli
+++ b/src/data/CCRingBuffer.mli
@@ -81,7 +81,7 @@ module type S = sig
   (** [create size] creates a new bounded buffer with given size.
       The underlying array is allocated immediately and no further (large)
       allocation will happen from now on.
-      @raise Invalid_argument if the arguments is [< 1]. *)
+      @raise Invalid_argument if the argument is [< 1]. *)
 
   val copy : t -> t
   (** Make a fresh copy of the buffer. *)
@@ -93,12 +93,12 @@ module type S = sig
   (** Number of elements currently stored in the buffer. *)
 
   val is_full : t -> bool
-  (** true if pushing an element would erase another element.
+  (** [true] if pushing an element would erase another element.
       @since 1.3 *)
 
   val blit_from : t -> Array.t -> int -> int -> unit
   (** [blit_from buf from_buf o len] copies the slice [o, ... o + len - 1] from
-      a input buffer [from_buf] to the end of the buffer.
+      an input buffer [from_buf] to the end of the buffer.
       If the slice is too large for the buffer, only the last part of the array
       will be copied.
       @raise Invalid_argument if [o,len] is not a valid slice of [s]. *)
@@ -142,12 +142,12 @@ module type S = sig
       being its relative index within [buf]. *)
 
   val get_front : t -> int -> Array.elt
-  (** [get_front buf i] returns the [i]-th element of [buf] from the front, ie
+  (** [get_front buf i] returns the [i]-th element of [buf] from the front, i.e.
       the one returned by [take_front buf] after [i-1] calls to [junk_front buf].
       @raise Invalid_argument if the index is invalid (> [length buf]). *)
 
   val get_back : t -> int -> Array.elt
-  (** [get_back buf i] returns the [i]-th element of [buf] from the back, ie
+  (** [get_back buf i] returns the [i]-th element of [buf] from the back, i.e.
       the one returned by [take_back buf] after [i-1] calls to [junk_back buf].
       @raise Invalid_argument if the index is invalid (> [length buf]). *)
 
@@ -199,7 +199,7 @@ end
 (** An efficient byte based ring buffer *)
 module Byte : S with module Array = Array.Byte
 
-(** Makes a ring buffer module with the given array type. *)
+(** Makes a ring buffer module with the given array type *)
 module MakeFromArray(A : Array.S) : S with module Array = A
 
 (** Buffer using regular arrays *)

--- a/src/data/CCWBTree.ml
+++ b/src/data/CCWBTree.ml
@@ -121,7 +121,7 @@ module type S = sig
       and [o = Some v] if [k, v] belonged to the map *)
 
   val merge : f:(key -> 'a option -> 'b option -> 'c option) -> 'a t -> 'b t -> 'c t
-  (** Similar to {!Map.S.merge} *)
+  (** Like {!Map.S.merge} *)
 
   val extract_min : 'a t -> key * 'a * 'a t
   (** [extract_min m] returns [k, v, m'] where [k,v] is the pair with the

--- a/src/data/CCWBTree.mli
+++ b/src/data/CCWBTree.mli
@@ -86,7 +86,7 @@ module type S = sig
       and [o = Some v] if [k, v] belonged to the map. *)
 
   val merge : f:(key -> 'a option -> 'b option -> 'c option) -> 'a t -> 'b t -> 'c t
-  (** Similar to {!Map.S.merge}. *)
+  (** Like {!Map.S.merge}. *)
 
   val extract_min : 'a t -> key * 'a * 'a t
   (** [extract_min m] returns [k, v, m'] where [k,v] is the pair with the

--- a/src/data/CCZipper.mli
+++ b/src/data/CCZipper.mli
@@ -7,13 +7,13 @@
 
 type 'a t = 'a list * 'a list
 (** The pair [l, r] represents the list [List.rev_append l r], but
-      with the focus on [r]. *)
+      with the focus on [r] *)
 
 val empty : 'a t
 (** Empty zipper. *)
 
 val is_empty : _ t -> bool
-(** Empty zipper? Returns true iff the two lists are empty. *)
+(** Empty zipper? Returns [true] iff the two lists are empty. *)
 
 val to_list : 'a t -> 'a list
 (** Convert the zipper back to a list.

--- a/src/iter/CCKList.mli
+++ b/src/iter/CCKList.mli
@@ -155,22 +155,22 @@ val merge : 'a ord -> 'a t -> 'a t -> 'a t
 (** Merge two sorted iterators into a sorted iterator. *)
 
 val zip : 'a t -> 'b t -> ('a * 'b) t
-(** Combine elements pairwise. Stops as soon as one of the lists stops.
+(** Combine elements pairwise. Stop as soon as one of the lists stops.
     @since 0.13 *)
 
 val unzip : ('a * 'b) t -> 'a t * 'b t
-(** Splits each tuple in the list.
+(** Split each tuple in the list.
     @since 0.13 *)
 
 (** {2 Misc} *)
 
 val sort : cmp:'a ord -> 'a t -> 'a t
-(** Eager sort. Requires the iterator to be finite. [O(n ln(n))] time
+(** Eager sort. Require the iterator to be finite. [O(n ln(n))] time
     and space.
     @since 0.3.3 *)
 
 val sort_uniq : cmp:'a ord -> 'a t -> 'a t
-(** Eager sort that removes duplicate values. Requires the iterator to be
+(** Eager sort that removes duplicate values. Require the iterator to be
     finite. [O(n ln(n))] time and space.
     @since 0.3.3 *)
 
@@ -243,14 +243,14 @@ end
 val of_list : 'a list -> 'a t
 
 val to_list : 'a t -> 'a list
-(** Gather all values into a list *)
+(** Gather all values into a list. *)
 
 val of_array : 'a array -> 'a t
 (** Iterate on the array.
     @since 0.13 *)
 
 val to_array : 'a t -> 'a array
-(** Convert into array. Iterates twice.
+(** Convert into array. Iterate twice.
     @since 0.13 *)
 
 val to_rev_list : 'a t -> 'a list
@@ -268,4 +268,4 @@ val of_gen : 'a gen -> 'a t
 
 val pp : ?sep:string -> 'a printer -> 'a t printer
 (** Print the list with the given separator (default ",").
-    Does not print opening/closing delimiters. *)
+    Do not print opening/closing delimiters. *)

--- a/src/iter/CCKTree.mli
+++ b/src/iter/CCKTree.mli
@@ -91,7 +91,7 @@ val find : pset:'a pset -> ('a -> 'b option) -> 'a t -> 'b option
         | `Cst n -> Format.fprintf fmt "%d" n
         | `Plus n -> Format.fprintf fmt "%d" n;;
 
-      Format.printf "%a@." (CCKTree.print pp_node) (fib 8);;
+      Format.printf "%a@." (CCKTree.pp pp_node) (fib 8);;
     ]}
 *)
 
@@ -114,7 +114,7 @@ module Dot : sig
   ] (** Dot attributes for nodes *)
 
   type graph = (string * attribute list t list)
-  (** A dot graph is a name, plus a list of trees labelled with attributes. *)
+  (** A dot graph is a name, plus a list of trees labelled with attributes *)
 
   val mk_id : ('a, Buffer.t, unit, attribute) format4 -> 'a
   (** Using a formatter string, build an ID. *)

--- a/src/iter/CCLazy_list.mli
+++ b/src/iter/CCLazy_list.mli
@@ -17,7 +17,7 @@ val return : 'a -> 'a t
 (** Return a computed value. *)
 
 val is_empty : _ t -> bool
-(** Evaluates the head. *)
+(** Evaluate the head. *)
 
 val length : _ t -> int
 (** [length l] returns the number of elements in [l], eagerly (linear time).

--- a/src/threads/CCLock.mli
+++ b/src/threads/CCLock.mli
@@ -24,7 +24,7 @@ val try_with_lock : 'a t -> ('a -> 'b) -> 'b option
     fails, [try_with_lock l f] fails too but the lock is released.
     @since 0.22 *)
 
-(** Type allowing to manipulate the lock as a reference
+(** Type allowing to manipulate the lock as a reference.
     @since 0.13 *)
 module LockRef : sig
   type 'a t

--- a/src/threads/CCPool.mli
+++ b/src/threads/CCPool.mli
@@ -3,7 +3,7 @@
 
 (** {1 Thread Pool, and Futures}
 
-    Renamed and heavily updated from [CCFuture]
+    Renamed and heavily updated from [CCFuture].
     @since 0.16 *)
 
 type +'a state =
@@ -36,7 +36,7 @@ module Make(P : PARAM) : sig
   (** [active ()] is true as long as [stop()] has not been called yet. *)
 
   val stop : unit -> unit
-  (** After calling [stop ()], Most functions will raise Stopped.
+  (** After calling [stop ()], most functions will raise Stopped.
       This has the effect of preventing new tasks from being executed. *)
 
   (** {6 Futures}
@@ -45,7 +45,7 @@ module Make(P : PARAM) : sig
       that are executed in the pool using {!run}. *)
   module Fut : sig
     type 'a t
-    (** A future value of type 'a *)
+    (** A future value of type ['a] *)
 
     type 'a future = 'a t
 
@@ -70,7 +70,7 @@ module Make(P : PARAM) : sig
     val get : 'a t -> 'a
     (** Blocking get: wait for the future to be evaluated, and get the value,
         or the exception that failed the future is returned.
-        raise e if the future failed with e. *)
+        Raise e if the future failed with e. *)
 
     val state : 'a t -> 'a state
     (** State of the future. *)
@@ -106,7 +106,7 @@ module Make(P : PARAM) : sig
         in the array fails, [sequence_a l] fails too. *)
 
     val map_a : ('a -> 'b t) -> 'a array -> 'b array t
-    (** [map_l f a] maps [f] on every element of [a], and will return
+    (** [map_a f a] maps [f] on every element of [a], and will return
         the array of every result if all calls succeed, or an error otherwise. *)
 
     val sequence_l : 'a t list -> 'a list t

--- a/src/threads/CCTimer.mli
+++ b/src/threads/CCTimer.mli
@@ -3,7 +3,7 @@
 
 (** {1 Event timer}
 
-    Used to be part of [CCFuture]
+    Used to be part of [CCFuture].
     @since 0.16 *)
 
 type t


### PR DESCRIPTION
Some small corrections and ... some errors/questions:

 - File src/data/CCBitField.mli    (L12)   
```#install_printer B.pp;;``` -> Unbound value B.pp 

- The lines 'status: stable' (in CCRAL.mli & CCIntMap.mli) can be deleted, no?

- La galère Monomorphic

File src/data/CCFQueue.mli (L57)
    ```[take_back_l 2 (of_list [1;2;3;4]) = of_list [1;2], [3;4]]```
 -> Error: ...an expression was expected of type int. 
What is the best way to rewrite this line to avoid this error?


File src/data/CCCache.mli   (Code sample: L21)
    ```let f' = with_cache (lru 256) f;;``` 
-> Error: This expression has type eq:'a ......

Writing ... ```(lru (=) 256) f;;```  is accepted, but is it correct?   
