### PR TITLE
Add CCOpt.flatten

### DIFF
--- a/src/core/CCOpt.ml
+++ b/src/core/CCOpt.ml
@@ -208,3 +208,13 @@ let to_seq o k = match o with
 let pp ppx out = function
   | None -> Format.pp_print_string out "None"
   | Some x -> Format.fprintf out "@[Some %a@]" ppx x
+
+let flatten = function
+  | Some x -> x
+  | None -> None
+
+(*$T
+  flatten None = None
+  flatten (Some None) = None
+  flatten (Some (Some 1)) = Some 1
+*)

--- a/src/core/CCOpt.mli
+++ b/src/core/CCOpt.mli
@@ -122,6 +122,10 @@ val (<+>) : 'a t -> 'a t -> 'a t
 val choice : 'a t list -> 'a t
 (** [choice] returns the first non-[None] element of the list, or [None]. *)
 
+val flatten : 'a t t -> 'a t
+(** [flatten] transforms [Some x] into [x].
+    @since NEXT_RELEASE *)
+
 (** {2 Infix Operators}
     @since 0.16 *)
 


### PR DESCRIPTION
Hi!

There was `CCOpt.flat_map`, but no `CCOpt.flatten`. Rather than redefining it in our codebase I'm sure it can find a home in containers :smiley: 

Thanks!