### PR TITLE
Add CCOpt.guard

### DIFF
--- a/src/core/CCOpt.ml
+++ b/src/core/CCOpt.ml
@@ -218,3 +218,14 @@ let flatten = function
   flatten (Some None) = None
   flatten (Some (Some 1)) = Some 1
 *)
+
+let return_if b x =
+  if b then
+    Some x
+  else
+    None
+
+(*$T
+  return_if false 1 = None
+  return_if true 1 = Some 1
+*)

--- a/src/core/CCOpt.mli
+++ b/src/core/CCOpt.mli
@@ -126,6 +126,12 @@ val flatten : 'a t t -> 'a t
 (** [flatten] transforms [Some x] into [x].
     @since NEXT_RELEASE *)
 
+val return_if : bool -> 'a -> 'a t
+(** Apply [Some] or [None] depending on a boolean.
+    More precisely, [return_if false x] is [None],
+    and [return_if true x] is [Some x].
+    @since NEXT_RELEASE *)
+
 (** {2 Infix Operators}
     @since 0.16 *)
 


### PR DESCRIPTION
Hi!

Here is an `Alternative`-style `guard` function like the one available in Haskell.
I realize that this pattern might not be very common in OCaml (though we use it), and that it might be possible to find a better name (this is very different from `CCResult.guard` for example), so let me know what you think.

Thanks!