### PR TITLE
Fix Int32 and Int64 operators are not visible

### DIFF
--- a/AUTHORS.adoc
+++ b/AUTHORS.adoc
@@ -29,3 +29,4 @@
 - Dave Aitken (@actionshrimp)
 - Etienne Millon (@emillon)
 - Christopher Zimmermann (@madroach)
+- Jules Aguillon (@julow)

--- a/src/core/CCEqual.mli
+++ b/src/core/CCEqual.mli
@@ -36,10 +36,9 @@ val map : ('a -> 'b) -> 'b t -> 'a t
     [map fst int] compares values of type [(int * 'a)]  by their
       first component. *)
 
-val (>|=) : 'b t -> ('a -> 'b) -> 'a t
-(** Infix equivalent of {!map}. *)
-
 module Infix : sig
   val (>|=) : 'b t -> ('a -> 'b) -> 'a t
   (** Infix equivalent of {!map}. *)
 end
+
+include module type of Infix

--- a/src/core/CCInt32.mli
+++ b/src/core/CCInt32.mli
@@ -90,6 +90,8 @@ module Infix : sig
   val (<) : t -> t -> bool
 end
 
+include module type of Infix
+
 val equal : t -> t -> bool
 (** The equal function for 32-bit integers.
     Like {!Pervasives.(=) x y)}. *)

--- a/src/core/CCInt64.mli
+++ b/src/core/CCInt64.mli
@@ -90,6 +90,8 @@ module Infix : sig
   val (<) : t -> t -> bool
 end
 
+include module type of Infix
+
 val equal : t -> t -> bool
 (** The equal function for 64-bit integers.
     Like {!Pervasives.(=) x y)}. *)


### PR DESCRIPTION
Operators are defined in the Infix module.
This module was included in the .ml file but not in the .mli file

I also made an (maybe) unrelated change to CCEqual. I can remove it