### PR TITLE
More benchmarks for immutable vectors

### DIFF
--- a/benchs/jbuild
+++ b/benchs/jbuild
@@ -3,7 +3,7 @@
   ((names (run_benchs run_bench_hash))
    (libraries (containers containers.data containers.iter
                containers.thread benchmark gen sequence qcheck
-               batteries))
+               batteries clarity))
    (flags (:standard -w +a-4-42-44-48-50-58-32-60@8 -safe-string -color always))
    (ocamlopt_flags (:standard -O3 -color always
                     -unbox-closures -unbox-closures-factor 20))

--- a/benchs/run_benchs.ml
+++ b/benchs/run_benchs.ml
@@ -165,24 +165,24 @@ module L = struct
       ]
 
   let bench_push ?(time=2) n =
-    let l = CCList.(0 -- (n - 1)) in
-    let ral = CCRAL.of_list l in
-    let v = CCFun_vec.of_list l in
-    let bv = BatVect.of_list l in
-    let cv = Clarity.Vector.of_list l in
-    let map = List.fold_left (fun map i -> Int_map.add i i map) Int_map.empty l in
+    let l = ref CCList.empty in
+    let ral = ref CCRAL.empty in
+    let v = ref CCFun_vec.empty in
+    let bv = ref BatVect.empty in
+    let cv = ref Clarity.Vector.empty in
+    let map = ref Int_map.empty in
     let bench_map l () =
-      for i = 0 to n-1 do Sys.opaque_identity (ignore (Int_map.add i i l)) done
+      for i = 0 to n-1 do Sys.opaque_identity (l := Int_map.add i i !l) done
     and bench_ral l () =
       (* Note: Better implementation probably possible *)
-      for i = 0 to n-1 do Sys.opaque_identity (ignore (CCRAL.append l (CCRAL.return i))) done
+      for i = 0 to n-1 do Sys.opaque_identity (l := CCRAL.append !l (CCRAL.return i)) done
     and bench_funvec l () =
-      for i = 0 to n-1 do Sys.opaque_identity (ignore (CCFun_vec.push i l)) done
+      for i = 0 to n-1 do Sys.opaque_identity (l := CCFun_vec.push i !l) done
     and bench_batvec l () =
-      for i = 0 to n-1 do Sys.opaque_identity (ignore (BatVect.append i l)) done
+      for i = 0 to n-1 do Sys.opaque_identity (l := BatVect.append i !l) done
     and bench_clarity_vec l () =
       (* Note: Better implementation probably possible *)
-      for i = 0 to n-1 do Sys.opaque_identity (ignore (Clarity.Vector.append l (Clarity.Vector.pure i))) done
+      for i = 0 to n-1 do Sys.opaque_identity (l := Clarity.Vector.append !l (Clarity.Vector.pure i)) done
     in
     B.throughputN time ~repeat
       [ "Map.add", bench_map map, ()


### PR DESCRIPTION
- Add Map as a reference, as this is the only efficient implementation in OCaml's standard library
- Add Clarity.Vector from the [clarity](https://github.com/IndiscriminateCoding/clarity) library
- New benchmarks for set at index and push

What's missing:

- CCFun_vec.set (no implementation)
- CCRAL.push and Clarity.Vector.push were missing and implemented inefficiently in terms of append

Maybe interesting for later:

- `iter` / `map`/ `filter`
- `append` (concatenating two `'a t`s)
- `push_front`