### PR TITLE
Add CCResult.get_or_failwith

### DIFF
--- a/AUTHORS.adoc
+++ b/AUTHORS.adoc
@@ -31,3 +31,4 @@
 - Christopher Zimmermann (@madroach)
 - Jules Aguillon (@julow)
 - Metin Akat (@loxs)
+- Hongchang Wu (@hongchangwu)

--- a/src/core/CCResult.ml
+++ b/src/core/CCResult.ml
@@ -93,6 +93,15 @@ let get_or e ~default = match e with
   | Ok x -> x
   | Error _ -> default
 
+let get_or_failwith = function
+  | Ok x -> x
+  | Error msg -> failwith msg
+
+(*$T
+  get_or_failwith (Ok 1) = 1
+  try ignore @@ get_or_failwith (Error "e"); false with Failure msg -> msg = "e"
+*)
+
 let map_or f e ~default = match e with
   | Ok x -> f x
   | Error _ -> default

--- a/src/core/CCResult.mli
+++ b/src/core/CCResult.mli
@@ -84,6 +84,11 @@ val get_exn : ('a, _) t -> 'a
 val get_or : ('a, _) t -> default:'a -> 'a
 (** [get_or e ~default] returns [x] if [e = Ok x], [default] otherwise. *)
 
+val get_or_failwith : ('a, string) t -> 'a
+(** [get_or_failwith e] returns [x] if [e = Ok x], fails otherwise.
+    @raise Failure with [msg] if [e = Error msg].
+    @since NEXT_RELEASE *)
+
 val map_or : ('a -> 'b) ->  ('a, 'c) t -> default:'b -> 'b
 (** [map_or f e ~default] returns [f x] if [e = Ok x], [default] otherwise. *)
 


### PR DESCRIPTION
Useful for raising meaningful exceptions when dealing with results with string errors.

Equivalent functions include https://github.com/dbuenzli/rresult/blob/master/src/rresult.mli#L138 & https://github.com/janestreet/base/blob/master/src/result.mli#L60