### PR TITLE
Fix #235 for CCRingBuffer

### DIFF
--- a/src/data/CCRingBuffer.ml
+++ b/src/data/CCRingBuffer.ml
@@ -18,6 +18,10 @@ module Array = struct
     (** The type of an array instance *)
     type t
 
+    val dummy : elt
+    (** A dummy element used for empty slots in the array
+        @since NEXT_RELEASE *)
+
     val create : int -> t
     (** Make an array of the given size, filled with dummy elements *)
 
@@ -49,6 +53,7 @@ module Array = struct
   module Byte :
     S with type elt = char and type t = Bytes.t = struct
     type elt = char
+    let dummy = '\x00'
     include Bytes
   end
 
@@ -56,6 +61,7 @@ module Array = struct
     S with type elt = Elt.t and type t = Elt.t array = struct
     type elt = Elt.t
     type t = Elt.t array
+    let dummy = Elt.dummy
     let create size = Array.make size Elt.dummy
     let length = Array.length
     let get = Array.get

--- a/src/data/CCRingBuffer.mli
+++ b/src/data/CCRingBuffer.mli
@@ -121,7 +121,7 @@ module type S = sig
   (** Extract the current content into a list. *)
 
   val clear : t -> unit
-  (** Clear the content of the buffer. Doesn't actually destroy the content. *)
+  (** Clear the content of the buffer *)
 
   val is_empty :t -> bool
   (** Is the buffer empty (i.e. contains no elements)? *)

--- a/src/data/CCRingBuffer.mli
+++ b/src/data/CCRingBuffer.mli
@@ -26,6 +26,10 @@ module Array : sig
     (** The type of an array instance *)
     type t
 
+    val dummy : elt
+    (** A dummy element used for empty slots in the array
+        @since NEXT_RELEASE *)
+
     val create : int -> t
     (** Make an array of the given size, filled with dummy elements. *)
 


### PR DESCRIPTION
A few notes:

- I added `dummy` to the signature of the Array in order to use it from `MakeFromArray`, which is a breaking change and not terribly nice. Open to better suggestions (add the `Elt` submodule to `Array`?)
- It doesn't seem to be possible to add comments to `$inject` blocks
- On my machine, `live_blocks` is 2 if deleting is properly implemented and `capacity b + 2` otherwise, so I believe the GC test is reasonably stable, but of course I'm also open to other approaches