### PR TITLE
Remove unused reference in CCIO.read_chunks

### DIFF
--- a/AUTHORS.adoc
+++ b/AUTHORS.adoc
@@ -34,3 +34,4 @@
 - Francois Berenger (@UnixJunkie)
 - Hongchang Wu (@hongchangwu)
 - Nathan Rebours (@NathanReb)
+- @rymdhund

--- a/src/core/CCIO.ml
+++ b/src/core/CCIO.ml
@@ -67,14 +67,11 @@ let with_in ?(mode=0o644) ?(flags=[Open_text]) filename f =
 
 let read_chunks ?(size=1024) ic =
   let buf = Bytes.create size in
-  let eof = ref false in
   let next() =
-    if !eof then None
-    else
-      let n = input ic buf 0 size in
-      if n = 0
-      then None
-      else Some (Bytes.sub_string buf 0 n)
+    let n = input ic buf 0 size in
+    if n = 0
+    then None
+    else Some (Bytes.sub_string buf 0 n)
   in
   next
 


### PR DESCRIPTION
It looks like the eof reference was accidentally left behind after some old refactoring