### PR TITLE
Re-enable mdx tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ val map : string IntMap.t = <abstr>
     (IntMap.pp CCFormat.int CCFormat.string_quoted)
     map;;
 map =
-  1->"1", 2->"2", 3->"3", 4->"4", 5->"5", 
+  1->"1", 2->"2", 3->"3", 4->"4", 5->"5",
   6->"6", 7->"7", 8->"8", 9->"9"
 - : unit = ()
 

--- a/containers.opam
+++ b/containers.opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "dune" { >= "1.1" }
+  "dune" { >= "1.11" }
   "dune-configurator"
   "result"
   "uchar"
@@ -21,6 +21,7 @@ depends: [
   "iter" { with-test }
   "gen" { with-test }
   "uutf" { with-test }
+  "mdx" { with-test & >= "1.5.0" & < "2.0.0" }
   "odoc" { with-doc }
   "ocaml" { >= "4.02.0" }
 ]

--- a/dune
+++ b/dune
@@ -1,7 +1,7 @@
 (rule
- (target README.md.corrected)
+ (targets README.md.corrected)
  (deps (package containers))
- (action (run ocaml-mdx test %{dep:README.md} -o %{target})))
+ (action (run ocaml-mdx test %{dep:README.md} -o %{targets})))
 
 (alias
  (name runtest)

--- a/dune
+++ b/dune
@@ -1,8 +1,8 @@
+(rule
+ (target README.md.corrected)
+ (deps (package containers))
+ (action (run ocaml-mdx test %{dep:README.md} -o %{target})))
 
-;(alias
-; (name runtest)
-; (deps README.md)
-; (action (progn
-;          (run mdx test %{deps})
-;          (diff? %{deps} %{deps}.corrected))))
-
+(alias
+ (name runtest)
+ (action (diff README.md README.md.corrected)))

--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,1 @@
-(lang dune 1.0)
+(lang dune 1.11)

--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,1 @@
-(lang dune 1.11)
+(lang dune 1.1)


### PR DESCRIPTION
We recently released `mdx.1.5.0` which contains fixes for some of the bugs you ran into so I took the liberty to open a PR re-enabling the mdx check of the README.

I also rewrote the dune rules by hand as `mdx rule` still needs to be improved a little. As a matter of fact it's going to be replaced by a proper dune integration for mdx in an hopefully near future!

Let me know what you think!