### PR TITLE
Avoid catch-all handlers

### DIFF
--- a/src/core/CCChar.ml
+++ b/src/core/CCChar.ml
@@ -13,7 +13,7 @@ let pp_buf = Buffer.add_char
 let pp = Format.pp_print_char
 
 let of_int_exn = Char.chr
-let of_int c = try Some (of_int_exn c) with _ -> None
+let of_int c = try Some (of_int_exn c) with Invalid_argument _ -> None
 let to_int = Char.code
 
 let to_string c = String.make 1 c

--- a/src/core/CCFloat.ml
+++ b/src/core/CCFloat.ml
@@ -114,7 +114,7 @@ let of_string_exn (a:string) = Stdlib.float_of_string a
 let of_string (a:string) = Stdlib.float_of_string a
 let of_string_opt (a:string) =
   try Some (Stdlib.float_of_string a)
-  with _ -> None
+  with Failure _ -> None
 
 
 let random n st = Random.State.float st n

--- a/src/core/CCIO.ml
+++ b/src/core/CCIO.ml
@@ -222,11 +222,7 @@ let with_in_out ?(mode=0o644) ?(flags=[Open_creat]) filename f =
 let tee funs g () = match g() with
   | None -> None
   | Some x as res ->
-    List.iter
-      (fun f ->
-         try f x
-         with _ -> ()
-      ) funs;
+    List.iter (fun f -> f x) funs;
     res
 
 (* TODO: lines/unlines:  string gen -> string gen *)

--- a/src/core/CCIO.mli
+++ b/src/core/CCIO.mli
@@ -143,7 +143,8 @@ val with_in_out : ?mode:int -> ?flags:open_flag list ->
 
 val tee : ('a -> unit) list -> 'a gen -> 'a gen
 (** [tee funs gen] behaves like [gen], but each element is given to
-    every function [f] in [funs] at the time the element is produced. *)
+    every function [f] in [funs] at the time the element is produced.
+    The returned generator will raise any exception that [f] raises *)
 
 (** {2 File and file names}
 

--- a/src/core/CCInt.ml
+++ b/src/core/CCInt.ml
@@ -202,7 +202,7 @@ let to_string = string_of_int
 
 let of_string s =
   try Some (int_of_string s)
-  with _ -> None
+  with Failure _ -> None
 
 type output = char -> unit
 

--- a/src/core/CCString.ml
+++ b/src/core/CCString.ml
@@ -589,7 +589,7 @@ let split_on_char c s: _ list =
 let split ~by s = Split.list_cpy ~by s
 
 let compare_versions a b =
-  let of_int s = try Some (int_of_string s) with _ -> None in
+  let of_int s = try Some (int_of_string s) with Failure _ -> None in
   let rec cmp_rec a b = match a(), b() with
     | None, None -> 0
     | Some _, None -> 1


### PR DESCRIPTION
Two other occurences weren't fixed because their exceptions are not documented: https://github.com/c-cube/ocaml-containers/blob/4bc01a0b8251dae4e2e5ae7648b5c03911804c23/src/unix/CCUnix.ml#L313-L314
 https://github.com/c-cube/ocaml-containers/blob/4bc01a0b8251dae4e2e5ae7648b5c03911804c23/src/core/CCIO.ml#L282 