### PR TITLE
More benchmarks

### DIFF
--- a/benchs/dune
+++ b/benchs/dune
@@ -1,11 +1,9 @@
-
-(executables
-  (names run_benchs run_bench_hash)
+ (executables
+  (names run_benchs run_bench_hash run_objsize)
   (libraries containers containers.data containers.iter
              containers.thread benchmark gen iter qcheck oseq
-             batteries)
+             batteries base core_kernel sek)
   (flags :standard -warn-error -3 -safe-string -color always -open CCShims_)
   (ocamlopt_flags :standard -O3 -color always
                    -unbox-closures -unbox-closures-factor 20)
   )
-

--- a/benchs/dune
+++ b/benchs/dune
@@ -2,7 +2,7 @@
   (names run_benchs run_bench_hash run_objsize)
   (libraries containers containers.data containers.iter
              containers.thread benchmark gen iter qcheck oseq
-             batteries base core_kernel sek)
+             batteries base sek)
   (flags :standard -warn-error -3 -safe-string -color always -open CCShims_)
   (ocamlopt_flags :standard -O3 -color always
                    -unbox-closures -unbox-closures-factor 20)

--- a/benchs/objsize.ml
+++ b/benchs/objsize.ml
@@ -23,12 +23,12 @@ open Obj
     comparisons are done using physical equality. *)
 
 module H = Hashtbl.Make(
-  struct 
-    type t = Obj.t 
-    let equal = (==) 
+  struct
+    type t = Obj.t
+    let equal = (==)
     let hash o = Hashtbl.hash (magic o : int)
   end)
-	     
+
 let node_table = (H.create 257 : unit H.t)
 
 let in_table o = try H.find node_table o; true with Not_found -> false
@@ -53,15 +53,15 @@ let rec traverse t =
       if tag < no_scan_tag then begin
 	count := !count + 1 + n;
 	for i = 0 to n - 1 do
-      	  let f = field t i in 
+      	  let f = field t i in
 	  if is_block f then traverse f
 	done
       end else if tag = string_tag then
-	count := !count + 1 + n 
+	count := !count + 1 + n
       else if tag = double_tag then
 	count := !count + size_of_double
       else if tag = double_array_tag then
-	count := !count + 1 + size_of_double * n 
+	count := !count + 1 + size_of_double * n
       else
 	incr count
     end

--- a/benchs/run_benchs.ml
+++ b/benchs/run_benchs.ml
@@ -804,11 +804,11 @@ module Iter_ = struct
   let bench_fold n =
     let iter () = Iter.fold (+) 0 Iter.(0 --n) in
     let gen () = Gen.fold (+) 0 Gen.(0 -- n) in
-    let klist () = OSeq.fold (+) 0 OSeq.(0 -- n) in
+    let oseq () = OSeq.fold (+) 0 OSeq.(0 -- n) in
     B.throughputN 3 ~repeat
       [ "iter.fold", iter, ();
         "gen.fold", gen, ();
-        "klist.fold", klist, ();
+        "oseq.fold", oseq, ();
       ]
 
   let bench_flat_map n =
@@ -823,7 +823,7 @@ module Iter_ = struct
     )
     in
     B.throughputN 3 ~repeat
-      [ "sequence.flat_map", iter, ();
+      [ "iter.flat_map", iter, ();
         "gen.flat_map", gen, ();
         "oseq.flat_map", oseq, ();
       ]

--- a/benchs/run_benchs.ml
+++ b/benchs/run_benchs.ml
@@ -17,9 +17,11 @@ let repeat = 3
 (* composition *)
 let (%%) f g x = f (g x)
 
+let opaque_ignore x = ignore (Sys.opaque_identity x)
+
 module L = struct
   let bench_iter ?(time=2) n =
-    let f i = ignore (Sys.opaque_identity i) in
+    let f i = opaque_ignore i in
     let l = CCList.(1 -- n) in
     let ral = CCRAL.of_list l in
     let vec = CCFun_vec.of_list l in
@@ -105,10 +107,10 @@ module L = struct
     let s1 = Sek.Persistent.of_array 0 (Array.of_list l1) in
     let s2 = Sek.Persistent.of_array 0 (Array.of_list l2) in
     let s3 = Sek.Persistent.of_array 0 (Array.of_list l3) in
-    let bench_list l1 l2 l3 () = ignore (Sys.opaque_identity (List.(append (append l1 l2) l3))) in
-    let bench_cclist l1 l2 l3 () = ignore (Sys.opaque_identity (CCList.(append (append l1 l2) l3))) in
-    let bench_funvec l1 l2 l3 () = ignore (Sys.opaque_identity (CCFun_vec.(append (append l1 l2) l3))) in
-    let bench_sek l1 l2 l3 () = ignore (Sys.opaque_identity (Sek.Persistent.(concat (concat l1 l2) l3))) in
+    let bench_list l1 l2 l3 () = opaque_ignore (List.(append (append l1 l2) l3)) in
+    let bench_cclist l1 l2 l3 () = opaque_ignore (CCList.(append (append l1 l2) l3)) in
+    let bench_funvec l1 l2 l3 () = opaque_ignore (CCFun_vec.(append (append l1 l2) l3)) in
+    let bench_sek l1 l2 l3 () = opaque_ignore (Sek.Persistent.(concat (concat l1 l2) l3)) in
     B.throughputN time ~repeat
       [ "CCList.append", bench_list l1 l2 l3, ()
       ; "List.append", bench_cclist l1 l2 l3, ()
@@ -146,17 +148,17 @@ module L = struct
     let map = List.fold_left (fun map i -> Int_map.add i i map) Int_map.empty l in
     let sek = Sek.Persistent.of_array 0 (Array.of_list l) in
     let bench_list l () =
-      for i = 0 to n-1 do Sys.opaque_identity (ignore (List.nth l i)) done
+      for i = 0 to n-1 do opaque_ignore (List.nth l i) done
     and bench_map l () =
-      for i = 0 to n-1 do Sys.opaque_identity (ignore (Int_map.find i l)) done
+      for i = 0 to n-1 do opaque_ignore (Int_map.find i l) done
     and bench_ral l () =
-      for i = 0 to n-1 do Sys.opaque_identity (ignore (CCRAL.get_exn l i)) done
+      for i = 0 to n-1 do opaque_ignore (CCRAL.get_exn l i) done
     and bench_funvec l () =
-      for i = 0 to n-1 do Sys.opaque_identity (ignore (CCFun_vec.get_exn i l)) done
+      for i = 0 to n-1 do opaque_ignore (CCFun_vec.get_exn i l) done
     and bench_batvec l () =
-      for i = 0 to n-1 do Sys.opaque_identity (ignore (BatVect.get l i)) done
+      for i = 0 to n-1 do opaque_ignore (BatVect.get l i) done
     and bench_sek l () =
-      for i = 0 to n-1 do Sys.opaque_identity (ignore (Sek.Persistent.get l i)) done
+      for i = 0 to n-1 do opaque_ignore (Sek.Persistent.get l i) done
     in
     B.throughputN time ~repeat
       [ "List.nth", bench_list l, ()
@@ -175,17 +177,17 @@ module L = struct
     let sek = Sek.Persistent.of_array 0 (Array.of_list l) in
     let map = List.fold_left (fun map i -> Int_map.add i i map) Int_map.empty l in
     let bench_map l () =
-      for i = 0 to n-1 do Sys.opaque_identity (ignore (Int_map.add i (-i) l)) done
+      for i = 0 to n-1 do opaque_ignore (Int_map.add i (-i) l) done
     and bench_ral l () =
-      for i = 0 to n-1 do Sys.opaque_identity (ignore (CCRAL.set l i (-i))) done
+      for i = 0 to n-1 do opaque_ignore (CCRAL.set l i (-i)) done
 (*
     and bench_funvec l () =
-      for _i = 0 to n-1 do Sys.opaque_identity (ignore ((* TODO *))) done
+      for _i = 0 to n-1 do opaque_ignore ((* TODO *)) done
 *)
     and bench_batvec l () =
-      for i = 0 to n-1 do Sys.opaque_identity (ignore (BatVect.set l i (-i))) done
+      for i = 0 to n-1 do opaque_ignore (BatVect.set l i (-i)) done
     and bench_sek l () =
-      for i = 0 to n-1 do Sys.opaque_identity (ignore (Sek.Persistent.set l i (-i))) done
+      for i = 0 to n-1 do opaque_ignore (Sek.Persistent.set l i (-i)) done
     in
     B.throughputN time ~repeat
       [ "Map.add", bench_map map, ()
@@ -202,18 +204,18 @@ module L = struct
     let map = ref Int_map.empty in
     let sek = ref (Sek.Persistent.create 0) in
     let bench_map l () =
-      for i = 0 to n-1 do Sys.opaque_identity (l := Int_map.add i i !l) done
+      for i = 0 to n-1 do l := Int_map.add i i !l done; opaque_ignore l
   (*
       and bench_ral l () =
         (* Note: Better implementation probably possible *)
-        for i = 0 to n-1 do Sys.opaque_identity (l := CCRAL.append !l (CCRAL.return i)) done
+        for i = 0 to n-1 do l := CCRAL.append !l (CCRAL.return i) done; opaque_ignore l
   *)
     and bench_funvec l () =
-      for i = 0 to n-1 do Sys.opaque_identity (l := CCFun_vec.push i !l) done
+      for i = 0 to n-1 do l := CCFun_vec.push i !l done; opaque_ignore l
     and bench_batvec l () =
-      for i = 0 to n-1 do Sys.opaque_identity (l := BatVect.append i !l) done
+      for i = 0 to n-1 do l := BatVect.append i !l done; opaque_ignore l
     and bench_sek l () =
-      for i = 0 to n-1 do Sys.opaque_identity (l := Sek.Persistent.push Sek.front !l i) done
+      for i = 0 to n-1 do l := Sek.Persistent.push Sek.front !l i done; opaque_ignore l
     in
     B.throughputN time ~repeat
       [ "Map.add", bench_map map, ()
@@ -232,19 +234,19 @@ module L = struct
     let sek = Sek.Persistent.of_array 0 (Array.of_list l) in
     let bench_map l () =
       let l = ref l in
-      for i = 0 to n-1 do Sys.opaque_identity (l := Int_map.remove i !l) done
+      for i = 0 to n-1 do l := Int_map.remove i !l done; opaque_ignore l
     and bench_ral l () =
       let l = ref l in
-      for _ = 0 to n-1 do Sys.opaque_identity (l := CCRAL.tl !l) done
+      for _ = 0 to n-1 do l := CCRAL.tl !l done; opaque_ignore l
     and bench_funvec l () =
       let l = ref l in
-      for _ = 0 to n-1 do Sys.opaque_identity (l := snd (CCFun_vec.pop_exn !l)) done
+      for _ = 0 to n-1 do l := snd (CCFun_vec.pop_exn !l) done; opaque_ignore l
     and bench_batvec l () =
       let l = ref l in
-      for _ = 0 to n-1 do Sys.opaque_identity (l := snd (BatVect.pop !l)) done
+      for _ = 0 to n-1 do l := snd (BatVect.pop !l) done; opaque_ignore l
     and bench_sek l () =
       let l = ref l in
-      for _ = 0 to n-1 do Sys.opaque_identity (l := snd (Sek.Persistent.pop Sek.back !l)) done
+      for _ = 0 to n-1 do l := snd (Sek.Persistent.pop Sek.back !l) done; opaque_ignore l
     in
     B.throughputN time ~repeat
       [ "Map.remove", bench_map map, ()

--- a/benchs/run_objsize.ml
+++ b/benchs/run_objsize.ml
@@ -1,4 +1,4 @@
-module Deque = Core_kernel.Deque
+(* module Deque = Core_kernel.Deque *)
 module Int_map = Map.Make(CCInt)
 module Int_set = Set.Make(CCInt)
 
@@ -29,7 +29,7 @@ let types = [
   "Sek.Persistent", (fun n -> Obj.magic @@ List.fold_left (Sek.Persistent.push front) (Sek.Persistent.create dummy) (ns n));
   "Sek.Ephemeral", (fun n -> Obj.magic @@ let c = Sek.Ephemeral.create dummy in iter_range n (Sek.Ephemeral.push front c); c);
   "CCVector", (fun n -> Obj.magic @@ let c = CCVector.create () in iter_range n (CCVector.push c); c);
-  "Core_kernel.Deque", (fun n -> Obj.magic @@ let c = Deque.create () in iter_range n (Deque.enqueue_back c); c);
+  (* "Core_kernel.Deque", (fun n -> Obj.magic @@ let c = Deque.create () in iter_range n (Deque.enqueue_back c); c); *)
   "Base.Queue", (fun n -> Obj.magic @@ let c = Base.Queue.create () in iter_range n (Base.Queue.enqueue c); c);
   "Stdlib.Queue", (fun n -> Obj.magic @@ Queue.of_seq (OSeq.init ~n id));
   "CCQueue", (fun n -> Obj.magic @@ CCDeque.of_list (ns n));

--- a/benchs/run_objsize.ml
+++ b/benchs/run_objsize.ml
@@ -1,0 +1,57 @@
+module Deque = Core_kernel.Deque
+module Int_map = Map.Make(CCInt)
+module Int_set = Set.Make(CCInt)
+
+let dup = CCPair.dup
+let id = CCFun.id
+let ns n = List.init n CCFun.id
+let iter_range n f = List.iter f (ns n)
+
+let gen_cons x xs =
+  let saw_x = ref false in
+  fun () ->
+    if !saw_x then (saw_x := true; Some x)
+    else xs ()
+
+let front = Sek.front
+let dummy = 0
+
+let types = [
+  "Stdlib.List", (fun n -> Obj.magic @@ ns n);
+  "Stdlib.Array", (fun n -> Obj.magic @@ Array.init n id);
+  "Stdlib.Hashtbl", (fun n -> Obj.magic @@ Hashtbl.of_seq (OSeq.init ~n dup));
+  "Base.Hashtbl", (fun n -> Obj.magic @@ Base.Hashtbl.Poly.of_alist_exn (List.init n dup));
+  "Stdlib.Map", (fun n -> Obj.magic @@ Int_map.of_seq (OSeq.init ~n dup));
+  "Stdlib.Set", (fun n -> Obj.magic @@ Int_set.of_seq (OSeq.init ~n id));
+  "CCFun_vec", (fun n -> Obj.magic @@ CCFun_vec.of_list (ns n));
+  "CCRAL", (fun n -> Obj.magic @@ CCRAL.of_list (ns n));
+  "BatVect", (fun n -> Obj.magic @@ BatVect.of_list (ns n));
+  "Sek.Persistent", (fun n -> Obj.magic @@ List.fold_left (Sek.Persistent.push front) (Sek.Persistent.create dummy) (ns n));
+  "Sek.Ephemeral", (fun n -> Obj.magic @@ let c = Sek.Ephemeral.create dummy in iter_range n (Sek.Ephemeral.push front c); c);
+  "CCVector", (fun n -> Obj.magic @@ let c = CCVector.create () in iter_range n (CCVector.push c); c);
+  "Core_kernel.Deque", (fun n -> Obj.magic @@ let c = Deque.create () in iter_range n (Deque.enqueue_back c); c);
+  "Base.Queue", (fun n -> Obj.magic @@ let c = Base.Queue.create () in iter_range n (Base.Queue.enqueue c); c);
+  "Stdlib.Queue", (fun n -> Obj.magic @@ Queue.of_seq (OSeq.init ~n id));
+  "CCQueue", (fun n -> Obj.magic @@ CCDeque.of_list (ns n));
+  "Iter", (fun n -> Obj.magic @@ List.fold_right Iter.cons (ns n) Iter.empty);
+  "Gen", (fun n -> Obj.magic @@ List.fold_right gen_cons (ns n) Gen.empty);
+  "Stdlib.Seq", (fun n -> Obj.magic @@ List.fold_right OSeq.cons (ns n) OSeq.empty);
+]
+
+let () =
+  let sizes = [0; 1; 10; 100; 1000; 10000] in
+  Printf.printf "%-20s  " "";
+  sizes |> List.iter (fun n -> Printf.printf "%6d " n);
+  Printf.printf "\n";
+  types
+  |> List.iter (fun (name, create) ->
+      Printf.printf "%-20s: " name;
+      sizes
+      |> List.iter (fun n ->
+          let obj = create n in
+          let size = Objsize.size_w obj in
+          (* let size = Obj.reachable_words (Obj.repr obj) in *)
+          Printf.printf "%6d " size
+        );
+      Printf.printf "\n"
+    )


### PR DESCRIPTION
- Add test to print the object size of various containers in heap words
- Add [Sek.Persistent](http://cambium.inria.fr/~fpottier/sek/doc/sek/Sek/index.html)
- Add bench for iter to List
- Add bench for to_array, cons and fold (over a cons-ed structured) to Seq

The cons-ed variants of Iter/Gen/Seq are a bit silly since they are not usually used like that. I was just curious how well closures do, feel free to complain.

Adds dependencies to Base and Sek. I've commented out Core_kernel for now.

To do for later: Compare Sek.Ephemeral, CCVector, CCRingBuffer, Base.Queue, etc.

#### Results

Object sizes:

```
                           0      1     10    100   1000  10000
Stdlib.List         :      0      3     30    300   3000  30000
Stdlib.Array        :      1      2     11    101   1001  10001
Stdlib.Hashtbl      :     22     26     62    470   4518  48198
Base.Hashtbl        :     29     32     83    543   4889  52838
Stdlib.Map          :      0      6     60    600   6000  60000
Stdlib.Set          :      0      5     50    500   5000  50000
CCFun_vec           :      5      7     16    125   1193  11888
CCRAL               :      0      6     36    312   3024  30024
BatVect             :      0      4     13    157   1561  15619
Sek.Persistent      :      2      3     14    300   1195  11164
Sek.Ephemeral       :    288    288    288    288   1181  11150
CCVector            :      4      8     15    113   1793  14337
Core_kernel.Deque   :     17     17     25    137   1033  16393
Base.Queue          :      8      8     23    135   1031  16391
Stdlib.Queue        :      4      7     34    304   3004  30004
CCQueue             :      3     11     35    275   2675  26675
Iter                :      4     10    118   1108  11008 110008
Gen                 :      4     13     85    805   8005  80005
Stdlib.Seq          :      4     10    118   1108  11008 110008
```

Benchs (on 4.10+flambda+no-flat-float-array):


```
Throughputs for "List.iter", "CCRAL.iter", "CCFun_vec.iter", "Sek.Persistent.iter" each running 3 times for at least 2 CPU seconds:
                          Rate        CCFun_vec.iter Sek.Persistent.iter CCRAL.iter List.iter
     CCFun_vec.iter  5830192+-14447/s             --                -10%       -45%      -49%
Sek.Persistent.iter  6448994+- 9073/s            11%                  --       -40%      -44%
         CCRAL.iter 10686995+-10562/s            83%                 66%         --       -7%
          List.iter 11494548+-12076/s            97%                 78%         8%        --
**********************************************************************
*** Run benchmarks for path "list.iter.10000"

Throughputs for "List.iter", "CCRAL.iter", "CCFun_vec.iter", "Sek.Persistent.iter" each running 3 times for at least 2 CPU seconds:
                       Rate       CCFun_vec.iter Sek.Persistent.iter List.iter CCRAL.iter
     CCFun_vec.iter 66289+- 281/s             --                 -1%      -19%       -20%
Sek.Persistent.iter 67191+-  94/s             1%                  --      -18%       -19%
          List.iter 82210+-  40/s            24%                 22%        --      [-1%]
         CCRAL.iter 83000+-1990/s            25%                 24%      [1%]         --
**********************************************************************
*** Run benchmarks for path "list.iter.100000"

Throughputs for "List.iter", "CCRAL.iter", "CCFun_vec.iter", "Sek.Persistent.iter" each running 3 times for at least 4 CPU seconds:
                      Rate     CCFun_vec.iter Sek.Persistent.iter List.iter CCRAL.iter
     CCFun_vec.iter 6173+-34/s             --                 -4%      -20%       -21%
Sek.Persistent.iter 6460+-51/s             5%                  --      -17%       -17%
          List.iter 7765+-52/s            26%                 20%        --      [-1%]
         CCRAL.iter 7807+-57/s            26%                 21%      [1%]         --
**********************************************************************
*** Run benchmarks for path "list.append.100"

Throughputs for "CCList.append", "List.append", "CCFun_vec.append", "Sek.concat" each running 3 times for at least 2 CPU seconds:
                       Rate        CCFun_vec.append CCList.append List.append Sek.concat
CCFun_vec.append    82551+-  370/s               --          -84%        -88%       -99%
   CCList.append   517673+- 8970/s             527%            --        -22%       -96%
     List.append   664560+- 4677/s             705%           28%          --       -95%
      Sek.concat 12791186+-12811/s           15395%         2371%       1825%         --
**********************************************************************
*** Run benchmarks for path "list.append.10000"

Throughputs for "CCList.append", "List.append", "CCFun_vec.append", "Sek.concat" each running 3 times for at least 2 CPU seconds:
                      Rate       CCFun_vec.append CCList.append List.append Sek.concat
CCFun_vec.append     505+-   1/s               --          -83%        -83%      -100%
   CCList.append    2955+-  72/s             485%            --       [-1%]      -100%
     List.append    2987+-   2/s             492%          [1%]          --      -100%
      Sek.concat 2704805+-4214/s          535517%        91420%      90449%         --
**********************************************************************
*** Run benchmarks for path "list.append.100000"

Throughputs for "CCList.append", "List.append", "CCFun_vec.append", "Sek.concat" each running 3 times for at least 4 CPU seconds:
                      Rate        CCFun_vec.append List.append CCList.append Sek.concat
CCFun_vec.append    37.3+-  1.1/s               --        -46%          -62%      -100%
     List.append    68.6+-  0.3/s              84%          --          -30%      -100%
   CCList.append    97.8+-  0.5/s             162%         43%            --      -100%
      Sek.concat 1820356+-11368/s         4881791%    2654756%      1861230%         --
**********************************************************************
*** Run benchmarks for path "list.set.100"

Throughputs for "Map.add", "RAL.set", "batvec.set", "Sek.Persistent.set" each running 3 times for at least 2 CPU seconds:
                       Rate        batvec.set Sek.Persistent.set Map.add RAL.set
        batvec.set 168184+- 1802/s         --                -5%    -51%    -70%
Sek.Persistent.set 177048+-  161/s         5%                 --    -49%    -69%
           Map.add 343827+- 2871/s       104%                94%      --    -39%
           RAL.set 565568+-12362/s       236%               219%     64%      --
**********************************************************************
*** Run benchmarks for path "list.set.10000"

Throughputs for "Map.add", "RAL.set", "batvec.set", "Sek.Persistent.set" each running 3 times for at least 2 CPU seconds:
                     Rate    batvec.set Sek.Persistent.set    Map.add    RAL.set
        batvec.set  353+-6/s         --               -58%       -71%       -77%
Sek.Persistent.set  839+-2/s       138%                 --       -30%       -46%
           Map.add 1208+-8/s       242%                44%         --       -22%
           RAL.set 1551+-2/s       339%                85%        28%         --
**********************************************************************
*** Run benchmarks for path "list.set.100000"

Throughputs for "Map.add", "RAL.set", "batvec.set", "Sek.Persistent.set" each running 3 times for at least 4 CPU seconds:
                     Rate      batvec.set Sek.Persistent.set   Map.add   RAL.set
        batvec.set 20.6+-0.1/s         --               -68%      -79%      -83%
Sek.Persistent.set 64.0+-1.3/s       210%                 --      -35%      -46%
           Map.add 99.1+-0.6/s       380%                55%        --      -17%
           RAL.set  119+-  0/s       478%                86%       20%        --
**********************************************************************
*** Run benchmarks for path "list.nth.100"

Throughputs for "List.nth", "Map.find", "RAL.get", "funvec.get", "batvec.get", "Sek.Persistent.get" each running 3 times for at least 2 CPU seconds:
                        Rate        List.nth Map.find RAL.get batvec.get funvec.get Sek.Persistent.get
          List.nth  281912+-   91/s       --     -57%    -81%       -83%       -85%               -87%
          Map.find  662001+- 3734/s     135%       --    -55%       -59%       -64%               -69%
           RAL.get 1482622+- 6655/s     426%     124%      --        -8%       -19%               -30%
        batvec.get 1618145+- 1172/s     474%     144%      9%         --       -11%               -23%
        funvec.get 1823665+- 8740/s     547%     175%     23%        13%         --               -13%
Sek.Persistent.get 2104465+-10803/s     646%     218%     42%        30%        15%                 --
**********************************************************************
*** Run benchmarks for path "list.nth.10000"

Throughputs for "List.nth", "Map.find", "RAL.get", "funvec.get", "batvec.get", "Sek.Persistent.get" each running 3 times for at least 2 CPU seconds:
                      Rate      List.nth RAL.get Map.find Sek.Persistent.get batvec.get funvec.get
          List.nth  19.0+-0.1/s       --    -99%     -99%               -99%      -100%      -100%
           RAL.get  2791+- 35/s   14609%      --    [-0%]               -25%       -27%       -78%
          Map.find  2804+- 34/s   14675%    [0%]       --               -25%       -27%       -78%
Sek.Persistent.get  3733+- 35/s   19572%     34%      33%                 --      [-3%]       -70%
        batvec.get  3836+- 39/s   20114%     37%      37%               [3%]         --       -70%
        funvec.get 12592+- 28/s   66254%    351%     349%               237%       228%         --
**********************************************************************
*** Run benchmarks for path "list.nth.100000"

Throughputs for "List.nth", "Map.find", "RAL.get", "funvec.get", "batvec.get", "Sek.Persistent.get" each running 3 times for at least 4 CPU seconds:
                      Rate        List.nth Map.find batvec.get Sek.Persistent.get RAL.get funvec.get
          List.nth 0.165+-0.001/s       --    -100%      -100%              -100%   -100%      -100%
          Map.find   232+-    1/s  140393%       --        -7%                -9%    -14%       -77%
        batvec.get   250+-    2/s  151243%       8%         --              [-2%]     -7%       -75%
Sek.Persistent.get   255+-    4/s  154366%      10%       [2%]                 --     -5%       -74%
           RAL.get   269+-    2/s  162490%      16%         7%                 5%      --       -73%
        funvec.get   999+-   15/s  604535%     330%       300%               291%    272%         --
**********************************************************************
*** Run benchmarks for path "list.push.100"

Throughputs for "Map.add", "Sek.Persistent.push", "funvec.push", "batvec.append" each running 3 times for at least 2 CPU seconds:
                        Rate       funvec.push batvec.append Sek.Persistent.push Map.add
        funvec.push  58516+-3022/s          --          -67%                -87%    -88%
      batvec.append 177745+-1931/s        204%            --                -62%    -65%
Sek.Persistent.push 467219+-2432/s        698%          163%                  --     -7%
            Map.add 504116+-1922/s        762%          184%                  8%      --
**********************************************************************
*** Run benchmarks for path "list.push.10000"

Throughputs for "Map.add", "Sek.Persistent.push", "funvec.push", "batvec.append" each running 3 times for at least 2 CPU seconds:
                      Rate      funvec.push batvec.append Map.add Sek.Persistent.push
        funvec.push  584+- 27/s          --          -67%    -68%                -87%
      batvec.append 1774+- 29/s        204%            --   [-2%]                -61%
            Map.add 1802+-  1/s        208%          [2%]      --                -61%
Sek.Persistent.push 4584+-110/s        685%          158%    154%                  --
**********************************************************************
*** Run benchmarks for path "list.push.100000"

Throughputs for "Map.add", "Sek.Persistent.push", "funvec.push", "batvec.append" each running 3 times for at least 4 CPU seconds:
                      Rate      funvec.push Map.add batvec.append Sek.Persistent.push
        funvec.push 54.6+-4.3/s          --    -61%          -69%                -88%
            Map.add  141+-  1/s        158%      --          -20%                -70%
      batvec.append  175+-  2/s        220%     24%            --                -63%
Sek.Persistent.push  472+-  5/s        765%    236%          170%                  --
**********************************************************************
*** Run benchmarks for path "list.pop.100"

Throughputs for "Map.remove", "RAL.tl", "funvec.pop", "batvec.pop", "Sek.Persistent.pop" each running 3 times for at least 2 CPU seconds:
                        Rate       funvec.pop batvec.pop Sek.Persistent.pop Map.remove RAL.tl
        funvec.pop  222099+-4688/s         --       -18%               -49%       -54%   -93%
        batvec.pop  270444+-8515/s        22%         --               -38%       -44%   -91%
Sek.Persistent.pop  436866+-4993/s        97%        62%                 --       -10%   -86%
        Map.remove  486301+- 850/s       119%        80%                11%         --   -84%
            RAL.tl 3072448+-4309/s      1283%      1036%               603%       532%     --
**********************************************************************
*** Run benchmarks for path "list.pop.10000"

Throughputs for "Map.remove", "RAL.tl", "funvec.pop", "batvec.pop", "Sek.Persistent.pop" each running 3 times for at least 2 CPU seconds:
                      Rate      funvec.pop batvec.pop Map.remove Sek.Persistent.pop RAL.tl
        funvec.pop  1249+-  2/s         --      [-5%]       -31%               -84%   -95%
        batvec.pop  1315+- 47/s       [5%]         --       -27%               -83%   -94%
        Map.remove  1798+-  1/s        44%        37%         --               -77%   -92%
Sek.Persistent.pop  7714+- 51/s       518%       486%       329%                 --   -67%
            RAL.tl 23212+-241/s      1759%      1665%      1191%               201%     --
**********************************************************************
*** Run benchmarks for path "list.pop.100000"

Throughputs for "Map.remove", "RAL.tl", "funvec.pop", "batvec.pop", "Sek.Persistent.pop" each running 3 times for at least 4 CPU seconds:
                     Rate      funvec.pop batvec.pop Map.remove Sek.Persistent.pop RAL.tl
        funvec.pop 91.1+-2.4/s         --       -14%       -34%               -88%   -95%
        batvec.pop  106+-  2/s        16%         --       -23%               -86%   -95%
        Map.remove  137+-  1/s        51%        29%         --               -82%   -93%
Sek.Persistent.pop  750+-  9/s       724%       608%       447%                 --   -63%
            RAL.tl 2001+- 41/s      2097%      1787%      1359%               167%     --
```


-----------

```
**********************************************************************
*** Run benchmarks for path "iter.to_array.1000"

Throughputs for "iter.to_array", "gen.to_array", "oseq.to_array" each running 3 times for at least 3 CPU seconds:
                 Rate        gen.to_array oseq.to_array iter.to_array
 gen.to_array 65379+-1881/s            --          -11%          -27%
oseq.to_array 73753+- 609/s           13%            --          -17%
iter.to_array 89299+-1246/s           37%           21%            --
**********************************************************************
*** Run benchmarks for path "iter.to_array.10000"

Throughputs for "iter.to_array", "gen.to_array", "oseq.to_array" each running 3 times for at least 3 CPU seconds:
                Rate       gen.to_array oseq.to_array iter.to_array
 gen.to_array 5432+- 77/s            --          -32%          -33%
oseq.to_array 8012+-181/s           48%            --         [-2%]
iter.to_array 8167+-212/s           50%          [2%]            --
**********************************************************************
*** Run benchmarks for path "iter.cons.1000"

Throughputs for "iter.cons", "gen.cons", "oseq.cons" each running 3 times for at least 3 CPU seconds:
              Rate        gen.cons iter.cons oseq.cons
 gen.cons 232393+-7330/s        --      -49%      -51%
iter.cons 454627+-8351/s       96%        --       -4%
oseq.cons 473828+-1251/s      104%        4%        --
**********************************************************************
*** Run benchmarks for path "iter.cons.10000"

Throughputs for "iter.cons", "gen.cons", "oseq.cons" each running 3 times for at least 3 CPU seconds:
             Rate       gen.cons oseq.cons iter.cons
 gen.cons  8595+-242/s        --      -58%      -59%
oseq.cons 20270+-248/s      136%        --       -4%
iter.cons 21096+-231/s      145%        4%        --
**********************************************************************
*** Run benchmarks for path "iter.cons.100000"

Throughputs for "iter.cons", "gen.cons", "oseq.cons" each running 3 times for at least 3 CPU seconds:
           Rate     gen.cons iter.cons oseq.cons
 gen.cons 219+-3/s        --      -50%      -53%
iter.cons 439+-8/s      101%        --       -5%
oseq.cons 463+-5/s      111%        5%        --
**********************************************************************
*** Run benchmarks for path "iter.cons_fold.1000"

Throughputs for "iter.cons_fold", "gen.cons_fold", "oseq.cons_fold" each running 3 times for at least 3 CPU seconds:
                   Rate        gen.cons_fold iter.cons_fold oseq.cons_fold
 gen.cons_fold 161766+- 486/s             --            -5%           -16%
iter.cons_fold 170957+-1498/s             6%             --           -12%
oseq.cons_fold 193330+-1945/s            20%            13%             --
**********************************************************************
*** Run benchmarks for path "iter.cons_fold.10000"

Throughputs for "iter.cons_fold", "gen.cons_fold", "oseq.cons_fold" each running 3 times for at least 3 CPU seconds:
                  Rate       gen.cons_fold oseq.cons_fold iter.cons_fold
 gen.cons_fold  7152+-206/s             --           -29%           -41%
oseq.cons_fold 10035+- 95/s            40%             --           -17%
iter.cons_fold 12114+-129/s            69%            21%             --
**********************************************************************
*** Run benchmarks for path "iter.cons_fold.100000"

Throughputs for "iter.cons_fold", "gen.cons_fold", "oseq.cons_fold" each running 3 times for at least 3 CPU seconds:
                Rate      gen.cons_fold oseq.cons_fold iter.cons_fold
 gen.cons_fold 199+- 0/s             --           -41%           -49%
oseq.cons_fold 339+-11/s            71%             --           -13%
iter.cons_fold 387+-13/s            95%            14%             --
```