### PR TITLE
harmonize CCList.mem and CCArray.mem

### DIFF
--- a/src/core/CCArray.ml
+++ b/src/core/CCArray.ml
@@ -201,7 +201,7 @@ exception Found
 
 let mem ?(eq = Stdlib.(=)) elt a =
   try
-    Array.iter (fun e -> if eq e elt then raise Found) a;
+    Array.iter (fun e -> if eq e elt then raise_notrace Found) a;
     false
   with Found -> true
 

--- a/src/core/CCArray.ml
+++ b/src/core/CCArray.ml
@@ -16,6 +16,7 @@ type 'a printer = Format.formatter -> 'a -> unit
 
 (** {2 Arrays} *)
 
+include CCShims_
 include CCShimsArray_
 
 let empty = [| |]

--- a/src/core/CCArray.ml
+++ b/src/core/CCArray.ml
@@ -197,8 +197,21 @@ let rev a =
   rev [| |] = [| |]
 *)
 
+exception Found
+
+let mem ?(eq = Stdlib.(=)) elt a =
+  try
+    Array.iter (fun e -> if eq e elt then raise Found) a;
+    false
+  with Found -> true
+
+(*$Q mem
+  Q.(array small_int) (fun a -> \
+  mem 1 a = (Array.mem 1 a))
+*)
+
 let rec find_aux f a i =
-  if i = Array.length a then None
+  if i >= Array.length a then None
   else match f i a.(i) with
     | Some _ as res -> res
     | None -> find_aux f a (i+1)

--- a/src/core/CCArray.mli
+++ b/src/core/CCArray.mli
@@ -132,6 +132,9 @@ val sort_ranking : ('a -> 'a -> int) -> 'a t -> int array
     [lookup_exn a.(i) (sorted a) = (sorted_ranking a).(i)].
     @since 1.0 *)
 
+val mem : ?eq:('a -> 'a -> bool) -> 'a -> 'a t -> bool
+(** [mem ~eq x a] return true if x is present in [a]. Linear time. *)
+
 val find_map : ('a -> 'b option) -> 'a t -> 'b option
 (** [find_map f a] returns [Some y] if there is an element [x] such
     that [f x = Some y]. Otherwise returns [None].

--- a/src/core/CCArray.mli
+++ b/src/core/CCArray.mli
@@ -133,7 +133,9 @@ val sort_ranking : ('a -> 'a -> int) -> 'a t -> int array
     @since 1.0 *)
 
 val mem : ?eq:('a -> 'a -> bool) -> 'a -> 'a t -> bool
-(** [mem ~eq x a] return true if x is present in [a]. Linear time. *)
+(** [mem ~eq x a] return true if x is present in [a]. Linear time.
+    @since NEXT_RELEASE
+*)
 
 val find_map : ('a -> 'b option) -> 'a t -> 'b option
 (** [find_map f a] returns [Some y] if there is an element [x] such

--- a/src/core/CCArrayLabels.mli
+++ b/src/core/CCArrayLabels.mli
@@ -132,7 +132,9 @@ val sort_ranking : f:('a -> 'a -> int) -> 'a t -> int array
     @since 1.0 *)
 
 val mem : ?eq:('a -> 'a -> bool) -> 'a -> 'a t -> bool
-(** [mem ~eq x a] return true if x is present in [a]. Linear time. *)
+(** [mem ~eq x a] return true if x is present in [a]. Linear time.
+    @since NEXT_RELEASE
+*)
 
 val find_map : f:('a -> 'b option) -> 'a t -> 'b option
 (** [find_map ~f a] returns [Some y] if there is an element [x] such

--- a/src/core/CCArrayLabels.mli
+++ b/src/core/CCArrayLabels.mli
@@ -131,6 +131,9 @@ val sort_ranking : f:('a -> 'a -> int) -> 'a t -> int array
     [lookup_exn a.(i) (sorted a) = (sorted_ranking a).(i)].
     @since 1.0 *)
 
+val mem : ?eq:('a -> 'a -> bool) -> 'a -> 'a t -> bool
+(** [mem ~eq x a] return true if x is present in [a]. Linear time. *)
+
 val find_map : f:('a -> 'b option) -> 'a t -> 'b option
 (** [find_map ~f a] returns [Some y] if there is an element [x] such
     that [~f x = Some y]. Otherwise returns [None].

--- a/src/core/CCList.ml
+++ b/src/core/CCList.ml
@@ -1215,11 +1215,16 @@ let group_join_by (type a) ?(eq=Stdlib.(=)) ?(hash=Hashtbl.hash) f c1 c2 =
   (Error "e2") (all_ok [Ok 1; Error "e2"; Error "e3"; Ok 4])
 *)
 
-let mem ~eq x l =
+let mem ?(eq=Stdlib.(=)) x l =
   let rec search eq x l = match l with
     | [] -> false
     | y::l' -> eq x y || search eq x l'
   in search eq x l
+
+(*$Q mem
+  Q.(small_list small_int) (fun l -> \
+  mem 1 l = (List.mem 1 l))
+*)
 
 let add_nodup ~eq x l =
   if mem ~eq x l then l else x::l
@@ -1545,7 +1550,7 @@ module Assoc = struct
       = [1, "1"; 2, "2"; 3, "3"]
   *)
 
-  let mem ~eq x l =
+  let mem ?(eq=Stdlib.(=)) x l =
     try ignore (search_exn eq l x); true
     with Not_found -> false
 

--- a/src/core/CCList.mli
+++ b/src/core/CCList.mli
@@ -544,7 +544,7 @@ val remove_one : eq:('a -> 'a -> bool) -> 'a -> 'a t -> 'a t
 (** [remove_one x set] removes one occurrence of [x] from [set]. Linear time.
     @since 0.11 *)
 
-val mem : eq:('a -> 'a -> bool) -> 'a -> 'a t -> bool
+val mem : ?eq:('a -> 'a -> bool) -> 'a -> 'a t -> bool
 (** Membership to the list. Linear time. *)
 
 val subset : eq:('a -> 'a -> bool) -> 'a t -> 'a t -> bool
@@ -607,7 +607,7 @@ module Assoc : sig
   val set : eq:('a->'a->bool) -> 'a -> 'b -> ('a,'b) t -> ('a,'b) t
   (** Add the binding into the list (erase it if already present). *)
 
-  val mem : eq:('a->'a->bool) -> 'a -> ('a,_) t -> bool
+  val mem : ?eq:('a->'a->bool) -> 'a -> ('a,_) t -> bool
   (** [mem x l] returns [true] iff [x] is a key in [l].
       @since 0.16 *)
 
@@ -637,7 +637,7 @@ val assq_opt : 'a -> ('a * 'b) t -> 'b option
     @since 1.5, but only
     @since 2.0 with labels *)
 
-val mem_assoc : eq:('a -> 'a -> bool) -> 'a -> ('a * _) t -> bool
+val mem_assoc : ?eq:('a -> 'a -> bool) -> 'a -> ('a * _) t -> bool
 (** Like [Assoc.mem].
     @since 2.0 *)
 

--- a/src/core/CCListLabels.mli
+++ b/src/core/CCListLabels.mli
@@ -548,7 +548,7 @@ val remove_one : eq:(('a -> 'a -> bool) [@keep_label]) -> 'a -> 'a t -> 'a t
 (** [remove_one x set] removes one occurrence of [x] from [set]. Linear time.
     @since 0.11 *)
 
-val mem : eq:(('a -> 'a -> bool) [@keep_label]) -> 'a -> 'a t -> bool
+val mem : ?eq:(('a -> 'a -> bool) [@keep_label]) -> 'a -> 'a t -> bool
 (** Membership to the list. Linear time. *)
 
 val subset : eq:(('a -> 'a -> bool) [@keep_label]) -> 'a t -> 'a t -> bool
@@ -611,7 +611,7 @@ module Assoc : sig
   val set : eq:(('a->'a->bool) [@keep_label]) -> 'a -> 'b -> ('a,'b) t -> ('a,'b) t
   (** Add the binding into the list (erase it if already present). *)
 
-  val mem : eq:(('a->'a->bool) [@keep_label]) -> 'a -> ('a,_) t -> bool
+  val mem : ?eq:(('a->'a->bool) [@keep_label]) -> 'a -> ('a,_) t -> bool
   (** [mem x l] returns [true] iff [x] is a key in [l].
       @since 0.16 *)
 
@@ -641,7 +641,7 @@ val assq_opt : 'a -> ('a * 'b) t -> 'b option
     @since 1.5, but only
     @since 2.0 with labels *)
 
-val mem_assoc : eq:(('a -> 'a -> bool) [@keep_label]) -> 'a -> ('a * _) t -> bool
+val mem_assoc : ?eq:(('a -> 'a -> bool) [@keep_label]) -> 'a -> ('a * _) t -> bool
 (** Like [Assoc.mem].
     @since 2.0 *)
 


### PR DESCRIPTION
They both have `?eq:('a -> 'a -> bool) -> 'a -> 'a t -> bool` as signature with `eq = Stdlib.(=)` by default.