### PR TITLE
feat(vector): transform shrink in resize

### DIFF
--- a/src/core/CCVector.ml
+++ b/src/core/CCVector.ml
@@ -112,7 +112,7 @@ let resize_ v newcapacity x =
   push v 0.; push v 1.;
   clear v;
   push v 0.; push v 1.; push v 7.; push v 10.; push v 12.;
-  shrink v 2;
+  truncate v 2;
   assert_equal 1. (fold (+.) 0. v);
   clear v;
   assert_equal 0 (size v);
@@ -461,7 +461,7 @@ let copy v = {
     equal (=) v v')
 *)
 
-let shrink v n =
+let truncate v n =
   let old_size = v.size in
   if n < old_size then (
     v.size <- n;
@@ -471,7 +471,7 @@ let shrink v n =
 
 (*$R
   let v = of_iter Iter.(1 -- 10) in
-  shrink v 5;
+  truncate v 5;
   OUnit.assert_equal [1;2;3;4;5] (to_list v);
 *)
 
@@ -481,7 +481,7 @@ let shrink v n =
     let l = to_list v in
     let h = Iter.(to_list (take n (of_list l))) in
     let v' = copy v in
-    shrink v' n;
+    truncate v' n;
     h = to_list v'
   )
 *)

--- a/src/core/CCVector.mli
+++ b/src/core/CCVector.mli
@@ -125,9 +125,11 @@ val top_exn : ('a, _) t -> 'a
 val copy : ('a,_) t -> ('a,'mut) t
 (** Shallow copy (may give an immutable or mutable vector). *)
 
-val shrink : ('a, rw) t -> int -> unit
-(** Shrink to the given size (remove elements above this size).
-    Does nothing if the parameter is bigger than the current size. *)
+val truncate : ('a, rw) t -> int -> unit
+(** Truncate to the given size (remove elements above this size).
+    Does nothing if the parameter is bigger than the current size.
+    [truncate] was called [shrink].
+    @since NEXT_RELEASE *)
 
 val shrink_to_fit : ('a, _) t -> unit
 (** Shrink internal array to fit the size of the vector


### PR DESCRIPTION
Fix name confusion between `shrink` and `shrink_to_fit` by introducing `resize` instead of `shrink`.