### PR TITLE
Add List.combine_chop and corresponding (and&) synchronized product

### DIFF
--- a/src/core/CCList.ml
+++ b/src/core/CCList.ml
@@ -572,14 +572,16 @@ let combine_gen l1 l2 =
     res1 = res2)
 *)
 
-let combine_chop l1 l2 =
+let combine_shortest l1 l2 =
   let rec direct i l1 l2 = match l1, l2 with
     | (_, []) | ([], _) -> []
     | _ when i=0 -> safe l1 l2 []
     | (x1::l1', x2::l2') -> (x1, x2) :: direct (i-1) l1' l2'
   and safe l1 l2 acc = match l1, l2 with
     | ([], _) | (_, []) -> List.rev acc
-    | (x1::l1', x2::l2') -> safe l1' l2' @@ (x1, x2) :: acc
+    | (x1::l1', x2::l2') ->
+      let acc = (x1,x2) :: acc in
+      safe l1' l2' acc
   in
   direct direct_depth_default_ l1 l2
 
@@ -1810,7 +1812,7 @@ module Infix = struct
       let[@inline]  monoid_product l1 l2 = product (fun x y -> x,y) l1 l2
     end)
     
-  let (and&) = combine_chop
+  let (and&) = combine_shortest
 end
 
 include Infix

--- a/src/core/CCList.ml
+++ b/src/core/CCList.ml
@@ -74,6 +74,8 @@ let is_empty = function
   | [] -> true
   | _::_ -> false
 
+let mguard c = if c then [ () ] else []
+
 (* max depth for direct recursion *)
 let direct_depth_default_ = 1000
 

--- a/src/core/CCList.ml
+++ b/src/core/CCList.ml
@@ -572,6 +572,29 @@ let combine_gen l1 l2 =
     res1 = res2)
 *)
 
+let combine_chop l1 l2 =
+  let rec direct i l1 l2 = match l1, l2 with
+    | (_, []) | ([], _) -> []
+    | _ when i=0 -> safe l1 l2 []
+    | (x1::l1', x2::l2') -> (x1, x2) :: direct (i-1) l1' l2'
+  and safe l1 l2 acc = match l1, l2 with
+    | ([], _) | (_, []) -> List.rev acc
+    | (x1::l1', x2::l2') -> safe l1' l2' @@ (x1, x2) :: acc
+  in
+  direct direct_depth_default_ l1 l2
+
+(*$T
+  (combine_chop [] []) = []
+  (combine_chop [1] []) = []
+  (combine_chop [] [1]) = []
+  (combine_chop (1--1025) (1--1026)) = List.combine (1--1025) (1--1025)
+  (combine_chop (1--1026) (1--1025)) = List.combine (1--1025) (1--1025)
+  combine_chop [1;2;3] [3;2;1] = List.combine [1;2;3] [3;2;1]
+  combine_chop (1 -- 100_000) (1 -- 100_000) = List.combine (1 -- 100_000) (1 -- 100_000)
+  combine_chop (1 -- 100_001) (1 -- 100_000) = List.combine (1 -- 100_000) (1 -- 100_000)
+*)
+
+
 let split l =
   let rec direct i l = match l with
     | [] -> [], []
@@ -1786,6 +1809,8 @@ module Infix = struct
       let (>>=) = (>>=)
       let[@inline]  monoid_product l1 l2 = product (fun x y -> x,y) l1 l2
     end)
+    
+  let (and&) = combine_chop
 end
 
 include Infix

--- a/src/core/CCList.mli
+++ b/src/core/CCList.mli
@@ -138,8 +138,8 @@ val combine_gen : 'a list -> 'b list -> ('a * 'b) gen
     @since 1.2, but only
     @since 2.2 with labels *)
 
-val combine_chop : 'a list -> 'b list -> ('a * 'b) list
-(** [combine [a1; …; am] [b1; …; bn]] is [[(a1,b1); …; (am,bm)]] if m <= n.
+val combine_shortest : 'a list -> 'b list -> ('a * 'b) list
+(** [combine_shortest [a1; …; am] [b1; …; bn]] is [[(a1,b1); …; (am,bm)]] if m <= n.
     Like {!combine} but stops at the shortest list rather than raising. 
     @since 3.1 *)
 
@@ -835,7 +835,7 @@ module Infix : sig
   include CCShimsMkLet_.S with type 'a t_let := 'a list
 
   val (and&) : 'a list -> 'b list -> ('a * 'b) list
-  (** [(and&)] is [combine_chop]. It allows to perform a synchronized product between two lists,
+  (** [(and&)] is [combine_shortest]. It allows to perform a synchronized product between two lists,
         stopping gently at the shortest. Usable both with [let+] and [let*].
     {[
         # let f xs ys zs = 

--- a/src/core/CCList.mli
+++ b/src/core/CCList.mli
@@ -322,6 +322,20 @@ val interleave : 'a list -> 'a list -> 'a list
 val pure : 'a -> 'a t
 (** [pure x] is [return x]. *)
 
+val mguard : bool -> unit t
+(** [mguard c] is [pure ()] if [c] is true, [[]] otherwise. 
+    This is useful to define a list by comprehension, e.g.:
+    {[
+      # let square_even xs =
+            let* x = xs in
+            let* () = mguard (x mod 2 = 0) in
+            return @@ x * x;;
+      val square_even : int list -> int list = <fun>
+      # square_even [1;2;4;3;5;2];;
+      - : int list = [4; 16; 4]
+    ]}
+    @since 3.1 *)
+
 val (<*>) : ('a -> 'b) t -> 'a t -> 'b t
 (** [funs <*> l] is [product (fun f x -> f x) funs l]. *)
 

--- a/src/core/CCList.mli
+++ b/src/core/CCList.mli
@@ -138,6 +138,11 @@ val combine_gen : 'a list -> 'b list -> ('a * 'b) gen
     @since 1.2, but only
     @since 2.2 with labels *)
 
+val combine_chop : 'a list -> 'b list -> ('a * 'b) list
+(** [combine [a1; …; am] [b1; …; bn]] is [[(a1,b1); …; (am,bm)]] if m <= n.
+    Like {!combine} but stops at the shortest list rather than raising. 
+    @since 3.1 *)
+
 val split : ('a * 'b) t -> 'a t * 'b t
 (** [split [(a1,b1); …; (an,bn)]] is [([a1; …; an], [b1; …; bn])].
     Transform a list of pairs into a pair of lists.
@@ -828,6 +833,23 @@ module Infix : sig
   (** Let operators on OCaml >= 4.08.0, nothing otherwise
       @since 2.8 *)
   include CCShimsMkLet_.S with type 'a t_let := 'a list
+
+  val (and&) : 'a list -> 'b list -> ('a * 'b) list
+  (** [(and&)] is [combine_chop]. It allows to perform a synchronized product between two lists,
+        stopping gently at the shortest. Usable both with [let+] and [let*].
+    {[
+        # let f xs ys zs = 
+            let+ x = xs 
+            and& y = ys 
+            and& z = zs in
+            x + y + z;;
+        val f : int list -> int list -> int list -> int list = <fun>
+        # f [1;2] [5;6;7] [10;10];;
+        - : int list = [16; 18]
+    ]}
+    @since 3.1 
+  *)
+
 end
 
 (** Let operators on OCaml >= 4.08.0, nothing otherwise

--- a/src/core/CCListLabels.mli
+++ b/src/core/CCListLabels.mli
@@ -326,6 +326,20 @@ val interleave : 'a list -> 'a list -> 'a list
 val pure : 'a -> 'a t
 (** [pure x] is [return x]. *)
 
+val mguard : bool -> unit t
+(** [mguard c] is [pure ()] if [c] is true, [[]] otherwise. 
+    This is useful to define a list by comprehension, e.g.:
+    {[
+      # let square_even xs =
+            let* x = xs in
+            let* () = mguard (x mod 2 = 0) in
+            return @@ x * x;;
+      val square_even : int list -> int list = <fun>
+      # square_even [1;2;4;3;5;2];;
+      - : int list = [4; 16; 4]
+    ]}
+    @since 3.1 *)
+
 val (<*>) : ('a -> 'b) t -> 'a t -> 'b t
 (** [funs <*> l] is [product (fun f x -> f x) funs l]. *)
 

--- a/src/core/CCListLabels.mli
+++ b/src/core/CCListLabels.mli
@@ -142,6 +142,11 @@ val combine_gen : 'a list -> 'b list -> ('a * 'b) gen
     @since 1.2, but only
     @since 2.2 with labels *)
 
+val combine_chop : 'a list -> 'b list -> ('a * 'b) list
+(** [combine [a1; …; am] [b1; …; bn]] is [[(a1,b1); …; (am,bm)]] if m <= n.
+    Like {!combine} but stops at the shortest list rather than raising. 
+    @since 3.1 *)
+
 val split : ('a * 'b) t -> 'a t * 'b t
 (** [split [(a1,b1); …; (an,bn)]] is [([a1; …; an], [b1; …; bn])].
     Transform a list of pairs into a pair of lists.
@@ -832,6 +837,22 @@ module Infix : sig
   (** Let operators on OCaml >= 4.08.0, nothing otherwise
       @since 2.8 *)
   include CCShimsMkLet_.S with type 'a t_let := 'a list
+
+  val (and&) : 'a list -> 'b list -> ('a * 'b) list
+  (** [(and&)] is [combine_chop]. It allows to perform a synchronized product between two lists,
+        stopping gently at the shortest. Usable both with [let+] and [let*].
+    {[
+        # let f xs ys zs = 
+            let+ x = xs 
+            and& y = ys 
+            and& z = zs in
+            x + y + z;;
+        val f : int list -> int list -> int list -> int list = <fun>
+        # f [1;2] [5;6;7] [10;10];;
+        - : int list = [16; 18]
+    ]}
+    @since 3.1 
+  *)
 end
 
 (** Let operators on OCaml >= 4.08.0, nothing otherwise


### PR DESCRIPTION
Implements #335.
Sorry, the former PR about `mguard` is also inside the PR and already pushed... Hope you can sort this out.

Also : I have only implemented the function for List for the time being. Indeed, it seems neither CCSeq nor OSeq come with a let syntax, and `zip` is already implemented in OSeq. 