### PR TITLE
CCFormat: append combinator and space/break/cut aliases

### DIFF
--- a/src/core/CCFormat.ml
+++ b/src/core/CCFormat.ml
@@ -117,7 +117,8 @@ let append ppa ppb fmt () =
   "foo" (to_string_test (append (return "foo") (return "")))
 *)
 
-let append_l = List.fold_left append (return "")
+let append_l ppl fmt () =
+  List.iter (fun pp -> pp fmt ()) ppl
 
 (*$= append_l & ~printer:(fun s -> CCFormat.sprintf "%S" s)
   "" (to_string_test @@ append_l [])

--- a/src/core/CCFormat.ml
+++ b/src/core/CCFormat.ml
@@ -107,6 +107,24 @@ let triple ?(sep=return ",@ ") ppa ppb ppc fmt (a, b, c) =
 let quad ?(sep=return ",@ ") ppa ppb ppc ppd fmt (a, b, c, d) =
   Format.fprintf fmt "%a%a%a%a%a%a%a" ppa a sep () ppb b sep () ppc c sep () ppd d
 
+let append ppa ppb fmt () =
+  ppa fmt ();
+  ppb fmt ()
+
+(*$= append & ~printer:(fun s -> CCFormat.sprintf "%S" s)
+  "foobar" (to_string_test (append (return "foo") (return "bar")))
+  "bar" (to_string_test (append (return "") (return "bar")))
+  "foo" (to_string_test (append (return "foo") (return "")))
+*)
+
+let append_l = List.fold_left append (return "")
+
+(*$= append_l & ~printer:(fun s -> CCFormat.sprintf "%S" s)
+  "" (to_string_test @@ append_l [])
+  "foobarbaz" (to_string_test @@ append_l (List.map return ["foo"; "bar"; "baz"]))
+  "3141" (to_string_test @@ append_l (List.map (const int) [3; 14; 1]))
+*)
+
 let within a b p out x =
   string out a;
   p out x;
@@ -444,3 +462,9 @@ end
   "[(Ok \"a b c\");(Error \"nope\")]" \
     (to_string Dump.(list (result string)) [Ok "a b c"; Error "nope"])
 *)
+
+module Infix = struct
+  let (++) = append
+end
+
+include Infix

--- a/src/core/CCFormat.ml
+++ b/src/core/CCFormat.ml
@@ -41,6 +41,9 @@ let nativeint fmt n = Format.fprintf fmt "%nd" n
 let string_quoted fmt s = Format.fprintf fmt "\"%s\"" s
 let flush = Format.pp_print_flush
 
+let space = Format.pp_print_space
+let cut = Format.pp_print_cut
+let break fmt (m, n) = Format.pp_print_break fmt m n
 let newline = Format.pp_force_newline
 
 let substring out (s,i,len): unit =

--- a/src/core/CCFormat.mli
+++ b/src/core/CCFormat.mli
@@ -34,6 +34,15 @@ val exn : exn printer
 (** Printer using {!Printexc.to_string}.
     @since 3.0 *)
 
+val space : unit printer
+(** Alias to {!pp_print_space}. *)
+
+val cut : unit printer
+(** Alias to {!pp_print_cut}. *)
+
+val break : (int * int) printer
+(** Tuple-ized {!printer} form of {!pp_print_break}. *)
+
 val newline : unit printer
 (** Force newline (see {!Format.pp_force_newline}).
     @since 1.2 *)

--- a/src/core/CCFormat.mli
+++ b/src/core/CCFormat.mli
@@ -35,13 +35,16 @@ val exn : exn printer
     @since 3.0 *)
 
 val space : unit printer
-(** Alias to {!pp_print_space}. *)
+(** Alias to {!pp_print_space}.
+    @since NEXT_RELEASE *)
 
 val cut : unit printer
-(** Alias to {!pp_print_cut}. *)
+(** Alias to {!pp_print_cut}.
+    @since NEXT_RELEASE *)
 
 val break : (int * int) printer
-(** Tuple-ized {!printer} form of {!pp_print_break}. *)
+(** Tuple-ized {!printer} form of {!pp_print_break}.
+    @since NEXT_RELEASE *)
 
 val newline : unit printer
 (** Force newline (see {!Format.pp_force_newline}).
@@ -96,10 +99,12 @@ val quad : ?sep:unit printer -> 'a printer -> 'b printer ->
   'c printer -> 'd printer -> ('a * 'b * 'c * 'd) printer
 
 val append : unit printer -> unit printer -> unit printer
-(** [append ppa ppb] first prints [ppa ()], then prints [ppb ()]. *)
+(** [append ppa ppb] first prints [ppa ()], then prints [ppb ()].
+    @since NEXT_RELEASE *)
 
 val append_l : unit printer list -> unit printer
-(** [append_l pps] runs the printers in [pps] sequentially. *)
+(** [append_l pps] runs the printers in [pps] sequentially.
+    @since NEXT_RELEASE *)
 
 val within : string -> string -> 'a printer -> 'a printer
 (** [within a b p] wraps [p] inside the strings [a] and [b]. Convenient,
@@ -358,7 +363,8 @@ end
 
 module Infix : sig
   val (++) : unit printer -> unit printer -> unit printer
-  (** Alias to {!append}. *)
+  (** Alias to {!append}.
+      @since NEXT_RELEASE *)
 end
 
 include module type of Infix

--- a/src/core/CCFormat.mli
+++ b/src/core/CCFormat.mli
@@ -95,6 +95,12 @@ val triple : ?sep:unit printer -> 'a printer -> 'b printer -> 'c printer -> ('a 
 val quad : ?sep:unit printer -> 'a printer -> 'b printer ->
   'c printer -> 'd printer -> ('a * 'b * 'c * 'd) printer
 
+val append : unit printer -> unit printer -> unit printer
+(** [append ppa ppb] first prints [ppa ()], then prints [ppb ()]. *)
+
+val append_l : unit printer list -> unit printer
+(** [append_l pps] runs the printers in [pps] sequentially. *)
+
 val within : string -> string -> 'a printer -> 'a printer
 (** [within a b p] wraps [p] inside the strings [a] and [b]. Convenient,
     for instances, for brackets, parenthesis, quotes, etc.
@@ -349,3 +355,10 @@ module Dump : sig
   val to_string : 'a t -> 'a -> string
   (** Alias to {!CCFormat.to_string}. *)
 end
+
+module Infix : sig
+  val (++) : unit printer -> unit printer -> unit printer
+  (** Alias to {!append}. *)
+end
+
+include module type of Infix


### PR DESCRIPTION
Resolves #314.  This PR adds the following to the `CCFormat` module:
- `space` (alias to `pp_print_space`), `cut` (alias to `pp_print_cut`), and `break` (wrapper around `pp_print_break` that turns it into an `(int * int) printer`).
- `append` (runs two `unit printer`s sequentially), `++` (alias to `append`), and `append_l` (runs a list of printers sequentially).