### PR TITLE
test: ensure tests are run by disabling dune cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build:
 	dune build @install -p $(PACKAGES)
 
 test: build
-	dune runtest --no-buffer --force
+	dune runtest --cache=disabled --no-buffer --force
 
 clean:
 	dune clean


### PR DESCRIPTION
In my environment the dune cache is enabled by default, and I observed that this lead to `make test` not actually running the tests. I don't know if this a good way to resolve this issue.