### PR TITLE
Add CCOpt.get_exn_or and deprecate CCOpt.get_exn

### DIFF
--- a/src/core/CCOpt.ml
+++ b/src/core/CCOpt.ml
@@ -110,6 +110,10 @@ let get_exn = function
   | Some x -> x
   | None -> invalid_arg "CCOpt.get_exn"
 
+let get_exn_or msg = function
+  | Some x -> x
+  | None -> invalid_arg msg
+
 let get_lazy default_fn x = match x with
   | None -> default_fn ()
   | Some y -> y

--- a/src/core/CCOpt.mli
+++ b/src/core/CCOpt.mli
@@ -88,7 +88,14 @@ val value : 'a t -> default:'a -> 'a
     @since 2.8 *)
 
 val get_exn : 'a t -> 'a
+[@@ocaml.deprecated "use CCOpt.get_exn_or instead"]
 (** [get_exn o] returns [x] if [o] is [Some x] or fails if [o] is [None].
+    @raise Invalid_argument if the option is [None].
+    @deprecated use {!get_exn_or} instead
+*)
+
+val get_exn_or : string -> 'a t -> 'a
+(** [get_exn msg o] returns [x] if [o] is [Some x] or fails with [Invalid_argument msg] if [o] is [None].
     @raise Invalid_argument if the option is [None]. *)
 
 val get_lazy : (unit -> 'a) -> 'a t -> 'a


### PR DESCRIPTION
`CCOpt.get_exn` has a lot of potential to create a horrible UX, since it fails with "CCOpt.get_exn" error message, which explains nothing, and it also makes exception traces not very informative since the failure comes inside of a library function.

It's better to force the user to supply a helpful error message, if the user chooses to use a function that raises an exception for `None`.

A real-life example of `get_exn` making someone's live miserable can be found at https://github.com/daypack-dev/timere/pull/23