### PR TITLE
Add CCHash.bytes

### DIFF
--- a/src/core/CCHash.ml
+++ b/src/core/CCHash.ml
@@ -86,14 +86,15 @@ let int32 (x:int32) = Hashtbl.hash x (* TODO: FNV *)
 let int64 (x:int64) = Hashtbl.hash x (* TODO: FNV *)
 let nativeint (x:nativeint) = Hashtbl.hash x
 
-let string (x:string) =
+let bytes (x:bytes) =
   let h = ref fnv_offset_basis in
-  for i = 0 to String.length x - 1 do
+  for i = 0 to Bytes.length x - 1 do
     h := Int64.(mul !h fnv_prime);
-    let byte = Char.code (String.unsafe_get x i) in
+    let byte = Char.code (Bytes.unsafe_get x i) in
     h := Int64.(logxor !h (of_int byte));
   done;
   Int64.to_int !h land max_int
+let string (x:string) = bytes (Bytes.unsafe_of_string x)
 
 (*$T
   int 42 >= 0

--- a/src/core/CCHash.mli
+++ b/src/core/CCHash.mli
@@ -31,6 +31,8 @@ val slice : string -> int -> int t
     into [state]. *)
 
 val bytes : bytes t
+(** Hash a byte array.
+    @since NEXT_RELEASE *)
 val string : string t
 
 val list : 'a t -> 'a list t

--- a/src/core/CCHash.mli
+++ b/src/core/CCHash.mli
@@ -30,6 +30,7 @@ val slice : string -> int -> int t
 (** [slice s i len state] hashes the slice [i, …, i+len-1] of [s]
     into [state]. *)
 
+val bytes : bytes t
 val string : string t
 
 val list : 'a t -> 'a list t


### PR DESCRIPTION
Same algorithm as `CCHash.string`.

Did not find test cases for `CCHash.string` so I did nothing for testing `CCHash.bytes`. Happy to add some test cases if needed.