### PR TITLE
Make CCSeq.to_array behave better with stateful sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.6.1
 
 - use `either` compatibility library instead of shims
+- make `CCSeq.to_array` only traverse the sequence once
 
 ## 3.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 3.6.1
 
 - use `either` compatibility library instead of shims
-- make `CCSeq.to_array` only traverse the sequence once
 
 ## 3.6
 

--- a/src/core/CCSeq.ml
+++ b/src/core/CCSeq.ml
@@ -406,7 +406,7 @@ let to_array l =
       let a = Array.make len init in
       (* Subtract 1 for len->index conversion and 1 for the removed [init] *)
       let idx = len - 2 in
-      ignore (List.fold_left (fun i x -> a.(i) <- x; i - 1) idx rest);
+      ignore (List.fold_left (fun i x -> a.(i) <- x; i - 1) idx rest : int);
       a
 
 (*$Q

--- a/src/core/CCSeq.mli
+++ b/src/core/CCSeq.mli
@@ -270,7 +270,7 @@ val of_array : 'a array -> 'a t
     @since 0.13 *)
 
 val to_array : 'a t -> 'a array
-(** Convert into array. Iterate twice.
+(** Convert into array.
     @since 0.13 *)
 
 val to_rev_list : 'a t -> 'a list


### PR DESCRIPTION
This PR suggests a change to `CCSeq.to_array`.

The change is motivated by the surprising behavior of `CCSeq.to_array` 
when the underlying seq depends on state. This surprising behavior can
be illustrated with this comparison between the behavior of `to_list` and
`to_array`:

```
# open Containers.Seq;;
# let r = ref 1 in 
  let s = unfold (fun i -> if i < 3 then let x = !r in incr r; Some (x, succ i) else None) 0 in
  to_array s
;;
- : int array = [|5; 6; 7|]
# let r = ref 1 in 
  let s = unfold (fun i -> if i < 3 then let x = !r in incr r; Some (x, succ i) else None) 0 in
  to_list s
;;
- : int list = [1; 2; 3]
```

The solution suggested here is to construct an intermediate list, to cash
the elements of the seq while we obtain the length of items, and thus 
prevent traversing the Seq twice. This requires the allocation of one 
intermediate list, but further allocations and traversals are avoided by
constructing the list and computing its length in one pass, and then
constructing the array from the last element, so we needn't reverse the list.

The PR also adds a test for the expected behavior with a stateful sequence.

*Some context:*

- I hit this surprising behavior doing one of this years advent of code exercises,
with a `Seq.t` reading from `stdin`.
- I discussed the issue and the possible fix a bit with @c-cube in chat.