### PR TITLE
adding opt_map to simplify result function application over optionals

### DIFF
--- a/src/core/CCResult.ml
+++ b/src/core/CCResult.ml
@@ -70,9 +70,11 @@ let of_exn_trace e =
 
 let opt_map f e = match e with 
   | None -> Ok None 
-  | Some x -> (match f x with 
+  | Some x ->
+    begin match f x with 
       | Ok x -> Ok (Some x)
-      | Error e -> Error e)
+      | Error e -> Error e
+    end
 
 let map f e = match e with
   | Ok x -> Ok (f x)

--- a/src/core/CCResult.ml
+++ b/src/core/CCResult.ml
@@ -68,6 +68,12 @@ let of_exn_trace e =
   in
   Error res
 
+let opt_map f e = match e with 
+  | None -> Ok None 
+  | Some x -> (match f x with 
+      | Ok x -> Ok (Some x)
+      | Error e -> Error e)
+
 let map f e = match e with
   | Ok x -> Ok (f x)
   | Error s -> Error s

--- a/src/core/CCResult.mli
+++ b/src/core/CCResult.mli
@@ -63,6 +63,9 @@ val add_ctxf : ('a, Format.formatter, unit, ('b, string) t -> ('b, string) t) fo
     ]}
     @since 1.2 *)
 
+val opt_map : ('a -> ('b, 'c) t) -> 'a option -> ('b option, 'c) t
+(** Map optional success *)
+
 val map : ('a -> 'b) -> ('a, 'err) t -> ('b, 'err) t
 (** Map on success. *)
 

--- a/src/core/CCResult.mli
+++ b/src/core/CCResult.mli
@@ -64,7 +64,8 @@ val add_ctxf : ('a, Format.formatter, unit, ('b, string) t -> ('b, string) t) fo
     @since 1.2 *)
 
 val opt_map : ('a -> ('b, 'c) t) -> 'a option -> ('b option, 'c) t
-(** Map optional success *)
+(** Map a fallible operation through an option.
+    @since NEXT_RELEASE *)
 
 val map : ('a -> 'b) -> ('a, 'err) t -> ('b, 'err) t
 (** Map on success. *)


### PR DESCRIPTION
A function I use a lot when applying CCResult over optionals - e.g. in a translation of ASTs a fragment like:
```
| AST_from.Return expr -> let+ expr = opt_map trans_expr expr in AST_to.Return expr
```
where `expr` is an optional expression of type `a option` and `trans_expr` maps from `a -> ('b,'err) result`