### PR TITLE
New assoc list helpers: `keys`, `values`, and `map_values`

### DIFF
--- a/src/core/CCList.ml
+++ b/src/core/CCList.ml
@@ -1814,6 +1814,12 @@ module Assoc = struct
     [1,"1"; 2,"2"] \
       (Assoc.remove ~eq:CCInt.equal 3 [1,"1"; 2,"2"] |> lsort)
   *)
+
+  let keys l = map (fun (k, _) -> k) l
+
+  let values l = map (fun (_, v) -> v) l
+
+  let map_values f l = map (fun (k, v) -> (k, f v)) l
 end
 
 let assoc = Assoc.get_exn

--- a/src/core/CCList.mli
+++ b/src/core/CCList.mli
@@ -747,6 +747,18 @@ module Assoc : sig
   val remove : eq:('a->'a->bool) -> 'a -> ('a,'b) t -> ('a,'b) t
   (** [remove ~eq k alist] returns the [alist] without the first pair with key [k], if any.
       @since 0.17 *)
+
+  val keys : ('a, 'b) t -> 'a list
+  (** [keys alist] returns a list of all keys of [alist].
+      @since 3.8 *)
+
+  val values : ('a, 'b) t -> 'b list
+  (** [values alist] returns a list of all values of [alist].
+      @since 3.8 *)
+
+  val map_values : ('b -> 'c) -> ('a, 'b) t -> ('a, 'c) t
+  (** [map_values f alist] applies function [f] to all values of [alist].
+      @since 3.8 *)
 end
 
 val assoc : eq:('a -> 'a -> bool) -> 'a -> ('a * 'b) t -> 'b

--- a/src/core/CCListLabels.mli
+++ b/src/core/CCListLabels.mli
@@ -711,6 +711,19 @@ module Assoc : sig
   val remove : eq:(('a->'a->bool) [@keep_label]) -> 'a -> ('a,'b) t -> ('a,'b) t
   (** [remove ~eq k alist] returns the [alist] without the first pair with key [k], if any.
       @since 0.17 *)
+
+  val keys : ('a, 'b) t -> 'a list
+  (** [keys alist] returns a list of all keys of [alist].
+      @since 3.8 *)
+
+  val values : ('a, 'b) t -> 'b list
+  (** [values alist] returns a list of all values of [alist].
+      @since 3.8 *)
+
+  val map_values : ('b -> 'c) -> ('a, 'b) t -> ('a, 'c) t
+  (** [map_values f alist] applies function [f] to all values of [alist].
+      @since 3.8 *)
+
 end
 
 val assoc : eq:(('a -> 'a -> bool) [@keep_label]) -> 'a -> ('a * 'b) t -> 'b


### PR DESCRIPTION
There's a bunch of simple assoc list helpers I use quite often and I think I'm not alone, so I'd like to add them to containers:

* `keys`: returns a list of all keys.
* `values`: returns a list of all values.
* `map_values`: applies a function to all values.

If you have objections against the naming of `map_values` or any implementation details, let me know. In particular, containers lean towards making a fold over an empty list a failure, while these functions return an empty list in that case—let me know if you think it should be handled differently.