### PR TITLE
Allow explicit fallback to bytecode for cpp

### DIFF
--- a/src/core/cpp/dune
+++ b/src/core/cpp/dune
@@ -3,5 +3,5 @@
 (executable
  (name cpp)
  (flags :standard -warn-error -a+8)
- (modes native)
+ (modes (best exe))
  (libraries dune.configurator))


### PR DESCRIPTION
We’ve suddenly started to see builds for [ocaml-multicore/multicorestests](https://github.com/ocaml-multicore/multicorestests) on bytecode-only OCaml when ocaml-containers became a recursive dependency because `cpp` is configured to build only on native.
See for instance this build:
https://github.com/shym/ocaml-containers/actions/runs/3674985755/jobs/6213853972#step:8:17
With this patch, the bytecode-only OCaml can build the project: https://github.com/shym/ocaml-containers/actions/runs/3675109065/jobs/6214130472

It might be interesting to go further and ensure that the test suite also can be run on bytecode?