### PR TITLE
Allow tests to run on a bytecode-only platform

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -21,6 +21,7 @@ jobs:
             - '4.07.x'
             - '4.08.x'
             - '4.14.x'
+            - 'ocaml-variants.5.0.0+options,ocaml-option-bytecode-only'
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
         ocaml-compiler:
             - '4.03.x'
             - '4.14.x'
+            - 'ocaml-variants.5.0.0+options,ocaml-option-bytecode-only'
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/tests/core/dune
+++ b/tests/core/dune
@@ -1,7 +1,7 @@
 (test
  (name t)
  (flags :standard -strict-sequence -warn-error -a+8 -open CCShims_)
- (modes native)
+ (modes (best exe))
  (package containers)
  (preprocess
   (action

--- a/tests/core/t_vector.ml
+++ b/tests/core/t_vector.ml
@@ -612,10 +612,11 @@ q
 
 (* check it frees memory properly *)
 t @@ fun () ->
-let s = "coucou" ^ "lol" in
 let w = Weak.create 1 in
-Weak.set w 0 (Some s);
-let v = of_list [ "a"; s ] in
+let v =
+  let s = "coucou" ^ "lol" in
+  Weak.set w 0 (Some s) ;
+  of_list [ "a"; s ] in
 filter_in_place (fun s -> String.length s <= 1) v;
 assert_equal 1 (length v);
 assert_equal "a" (get v 0);

--- a/tests/data/dune
+++ b/tests/data/dune
@@ -1,6 +1,6 @@
 (test
  (name t)
  (flags :standard -strict-sequence -warn-error -a+8 -open CCShims_)
- (modes native)
+ (modes (best exe))
  (package containers-data)
  (libraries containers containers-data containers_testlib iter gen))

--- a/tests/thread/dune
+++ b/tests/thread/dune
@@ -1,6 +1,6 @@
 (test
  (name t)
  (flags :standard -strict-sequence -warn-error -a+8 -open CCShims_)
- (modes native)
+ (modes (best exe))
  (package containers-thread)
  (libraries containers containers-thread containers_testlib iter threads))


### PR DESCRIPTION
As a followup to #421, this PR runs the test suite also on a bytecode-only switch, after fixing what must be fixed so that it works.