### PR TITLE
Fix CCMultiMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ to list authors based on the git commits.
 Assuming your are in a clone of the repository:
 
 1. Some dependencies are required, you'll need
-  `opam install benchmark qcheck-core iter gen mdx uutf`.
+  `opam install benchmark qcheck-core iter gen mdx uutf yojson`.
 2. run `make all` to enable everything (including tests).
 3. make your changes, commit, push, and open a PR.
 4. use `make test` without moderation! It must pass before a PR

--- a/src/data/CCMultiMap.ml
+++ b/src/data/CCMultiMap.ml
@@ -229,14 +229,14 @@ module type BIDIR = sig
 
   val find_left_iter : t -> left -> right iter
   (** Iterate on bindings for this given left-key
-      @since 3.12 *)
+      @since NEXT_RELEASE *)
 
   val find_right : t -> right -> left list
   (** List of values for this given right-key *)
 
   val find_right_iter : t -> right -> left iter
   (** Iterate on bindings for this given left-key
-      @since 3.12 *)
+      @since NEXT_RELEASE *)
 
   val find1_left : t -> left -> right option
   (** like {!find_left} but returns at most one value *)

--- a/src/data/CCMultiMap.ml
+++ b/src/data/CCMultiMap.ml
@@ -233,7 +233,8 @@ module type BIDIR = sig
       @since NEXT_RELEASE *)
 
   val find_right : t -> right -> left list
-  (** List of values for this given right-key *)
+  (** List of values for this given right-key.
+      This used to return an iter, but returns a list since NEXT_RELEASE. *)
 
   val find_right_iter : t -> right -> left iter
   (** Iterate on bindings for this given left-key

--- a/src/data/CCMultiMap.ml
+++ b/src/data/CCMultiMap.ml
@@ -225,7 +225,8 @@ module type BIDIR = sig
   (** Is the right key present in at least one pair? *)
 
   val find_left : t -> left -> right list
-  (** List of values for this given left-key *)
+  (** List of values for this given left-key.
+      This used to return an iter, but returns a list since NEXT_RELEASE. *)
 
   val find_left_iter : t -> left -> right iter
   (** Iterate on bindings for this given left-key

--- a/src/data/CCMultiMap.mli
+++ b/src/data/CCMultiMap.mli
@@ -30,7 +30,7 @@ module type S = sig
   val find : t -> key -> value list
   (** List of values for this key. *)
 
-  val find_iter : t -> key -> (value -> unit) -> unit
+  val find_iter : t -> key -> value iter
   (** Iterate on bindings for this key. *)
 
   val count : t -> key -> int
@@ -119,11 +119,19 @@ module type BIDIR = sig
   val mem_right : t -> right -> bool
   (** Is the right key present in at least one pair? *)
 
-  val find_left : t -> left -> right iter
-  (** Find all bindings for this given left-key. *)
+  val find_left : t -> left -> right list
+  (** List of values for this given left-key. *)
 
-  val find_right : t -> right -> left iter
-  (** Find all bindings for this given right-key. *)
+  val find_left_iter : t -> left -> right iter
+  (** Iterate on bindings for this given left-key.
+      @since 3.12 *)
+
+  val find_right : t -> right -> left list
+  (** List of values for this given right-key. *)
+
+  val find_right_iter : t -> right -> left iter
+  (** Iterate on bindings for this given left-key.
+      @since 3.12 *)
 
   val find1_left : t -> left -> right option
   (** Like {!find_left} but returns at most one value. *)

--- a/src/data/CCMultiMap.mli
+++ b/src/data/CCMultiMap.mli
@@ -124,14 +124,14 @@ module type BIDIR = sig
 
   val find_left_iter : t -> left -> right iter
   (** Iterate on bindings for this given left-key.
-      @since 3.12 *)
+      @since NEXT_RELEASE *)
 
   val find_right : t -> right -> left list
   (** List of values for this given right-key. *)
 
   val find_right_iter : t -> right -> left iter
   (** Iterate on bindings for this given left-key.
-      @since 3.12 *)
+      @since NEXT_RELEASE *)
 
   val find1_left : t -> left -> right option
   (** Like {!find_left} but returns at most one value. *)


### PR DESCRIPTION
The commit message documents all the changes made so I'll just paste it here:

> Rename functions find_left and find_right in the bidirectional multimap to find_left_iter and find_right_iter respectively to reflect their usage, and add new functions to replace the old find_left and find_right that return a list of values rather than an iterator, to make the signatures of CCMultiMap.S and CCMultiMap.BIDIR cohere. Additionally, change the return type of S.find_iter from `t -> key -> (value -> unit) -> unit` to `t -> key -> value iter`. These types are the same though, it's just for clarity since CCMultiMap already exposes an iter type

Note that this is a breaking change since it changes the signature of `CCMultiMap.BIDIR`. A cursory GitHub search did not reveal many usages of the bidirectional functor though so it should be relatively harmless. Also, the fact that the signature for `BIDIR` is inconsistent might be a reason why somebody wouldn't want to use the bidirectional multimap, that was almost the case for me personally, so I think this is a good change. 