### PR TITLE
feat: add CCVector.findi

### DIFF
--- a/src/core/CCVector.ml
+++ b/src/core/CCVector.ml
@@ -490,8 +490,24 @@ let find_internal_ p v =
   in
   check 0
 
+let find_internal_i_ p v =
+  let n = v.size in
+  let rec check i =
+    if i = n then
+      raise_notrace Not_found
+    else (
+      let x = v.vec.(i) in
+      if p x then
+        i,x
+      else
+        check (i + 1)
+    )
+  in
+  check 0
+
 let find_exn p v = try find_internal_ p v with Not_found -> raise Not_found
 let find p v = try Some (find_internal_ p v) with Not_found -> None
+let findi p v = try Some (find_internal_i_ p v) with Not_found -> None
 
 let find_map f v =
   let n = v.size in

--- a/src/core/CCVector.mli
+++ b/src/core/CCVector.mli
@@ -220,6 +220,9 @@ val for_all : ('a -> bool) -> ('a, _) t -> bool
 val find : ('a -> bool) -> ('a, _) t -> 'a option
 (** Find an element that satisfies the predicate. *)
 
+val findi : ('a -> bool) -> ('a, _) t -> (int * 'a) option
+(** Find an element and its index that satisfies the predicate. *)
+
 val find_exn : ('a -> bool) -> ('a, _) t -> 'a
 (** Find an element that satisfies the predicate, or
     @raise Not_found if no element does. *)


### PR DESCRIPTION
Add a function to return the index as well as the item found.  I think this is useful with `CCVector.slice_iter`.