### PR TITLE
Update CCEither.mli fixing typo in docstring

### DIFF
--- a/src/core/CCEither.mli
+++ b/src/core/CCEither.mli
@@ -2,7 +2,7 @@
 
 (** Either Monad
 
-    Module that is compatible with Either form OCaml 4.12 but can be use with any
+    Module that is compatible with Either from OCaml 4.12 but can be use with any
     ocaml version compatible with container
 
     @since 3.2


### PR DESCRIPTION
Changed "form OCaml 4.12" to "from OCaml 4.12".