### PR TITLE
Add `take_while` and `rtake_while` to `CCString`, addressing #463

### DIFF
--- a/src/core/CCEither.mli
+++ b/src/core/CCEither.mli
@@ -2,7 +2,7 @@
 
 (** Either Monad
 
-    Module that is compatible with Either form OCaml 4.12 but can be use with any
+    Module that is compatible with Either from OCaml 4.12 but can be use with any
     ocaml version compatible with container
 
     @since 3.2

--- a/src/core/CCString.ml
+++ b/src/core/CCString.ml
@@ -597,9 +597,9 @@ let rtake_while f s =
   let i = ref s_len_pred in
   while !i >= 0 && f (String.unsafe_get s !i) do
     decr i
-  done ;
-  if !i < s_len_pred
-    then String.sub s (!i + 1) (s_len_pred - !i)
+  done;
+  if !i < s_len_pred then
+    String.sub s (!i + 1) (s_len_pred - !i)
   else
     ""
 

--- a/src/core/CCString.ml
+++ b/src/core/CCString.ml
@@ -585,6 +585,24 @@ let take n s =
   else
     s
 
+let take_while p s =
+  let i = ref 0 in
+  while !i < String.length s && p (String.unsafe_get s !i) do
+    incr i
+  done;
+  String.sub s 0 !i
+
+let rtake_while p s =
+  let s_len_pred = String.length s - 1 in
+  let i = ref s_len_pred in
+  while !i >= 0 && p (String.unsafe_get s !i) do
+    decr i
+  done ;
+  if !i < s_len_pred
+    then String.sub s (!i + 1) (s_len_pred - !i)
+  else
+    ""
+
 let drop n s =
   if n < String.length s then
     String.sub s n (String.length s - n)

--- a/src/core/CCString.ml
+++ b/src/core/CCString.ml
@@ -585,17 +585,17 @@ let take n s =
   else
     s
 
-let take_while p s =
+let take_while f s =
   let i = ref 0 in
-  while !i < String.length s && p (String.unsafe_get s !i) do
+  while !i < String.length s && f (String.unsafe_get s !i) do
     incr i
   done;
   String.sub s 0 !i
 
-let rtake_while p s =
+let rtake_while f s =
   let s_len_pred = String.length s - 1 in
   let i = ref s_len_pred in
-  while !i >= 0 && p (String.unsafe_get s !i) do
+  while !i >= 0 && f (String.unsafe_get s !i) do
     decr i
   done ;
   if !i < s_len_pred

--- a/src/core/CCString.mli
+++ b/src/core/CCString.mli
@@ -183,13 +183,13 @@ val take : int -> string -> string
     @since 0.17 *)
 
 val take_while : (char -> bool) -> string -> string
-(** [take_while p s] keeps only the longest prefix [t] of [s] such that every
-    character [c] in [t] satisfies [p c].
+(** [take_while f s] keeps only the longest prefix [t] of [s] such that every
+    character [c] in [t] satisfies [f c].
     @since 3.16 *)
 
 val rtake_while : (char -> bool) -> string -> string
-(** [rtake_while p s] keeps only the longest suffix [t] of [s] such that every
-    character [c] in [t] satisfies [p c].
+(** [rtake_while f s] keeps only the longest suffix [t] of [s] such that every
+    character [c] in [t] satisfies [f c].
     @since 3.16 *)
 
 val drop : int -> string -> string

--- a/src/core/CCString.mli
+++ b/src/core/CCString.mli
@@ -182,6 +182,14 @@ val take : int -> string -> string
 (** [take n s] keeps only the [n] first chars of [s].
     @since 0.17 *)
 
+val take_while : (char -> bool) -> string -> string
+(** [take_while p s] keeps only the longest prefix [t] of [s] such that every
+    character [c] in [t] satisfies [f c]. *)
+
+val rtake_while : (char -> bool) -> string -> string
+(** [rtake_while p s] keeps only the longest suffix [t] of [s] such that every
+    character [c] in [t] satisfies [f c]. *)
+
 val drop : int -> string -> string
 (** [drop n s] removes the [n] first chars of [s].
     @since 0.17 *)

--- a/src/core/CCString.mli
+++ b/src/core/CCString.mli
@@ -184,11 +184,13 @@ val take : int -> string -> string
 
 val take_while : (char -> bool) -> string -> string
 (** [take_while p s] keeps only the longest prefix [t] of [s] such that every
-    character [c] in [t] satisfies [p c]. *)
+    character [c] in [t] satisfies [p c].
+    @since 3.16 *)
 
 val rtake_while : (char -> bool) -> string -> string
 (** [rtake_while p s] keeps only the longest suffix [t] of [s] such that every
-    character [c] in [t] satisfies [p c]. *)
+    character [c] in [t] satisfies [p c].
+    @since 3.16 *)
 
 val drop : int -> string -> string
 (** [drop n s] removes the [n] first chars of [s].

--- a/src/core/CCString.mli
+++ b/src/core/CCString.mli
@@ -184,11 +184,11 @@ val take : int -> string -> string
 
 val take_while : (char -> bool) -> string -> string
 (** [take_while p s] keeps only the longest prefix [t] of [s] such that every
-    character [c] in [t] satisfies [f c]. *)
+    character [c] in [t] satisfies [p c]. *)
 
 val rtake_while : (char -> bool) -> string -> string
 (** [rtake_while p s] keeps only the longest suffix [t] of [s] such that every
-    character [c] in [t] satisfies [f c]. *)
+    character [c] in [t] satisfies [p c]. *)
 
 val drop : int -> string -> string
 (** [drop n s] removes the [n] first chars of [s].

--- a/src/core/CCStringLabels.mli
+++ b/src/core/CCStringLabels.mli
@@ -193,14 +193,14 @@ val take : int -> string -> string
 (** [take n s] keeps only the [n] first chars of [s].
     @since 0.17 *)
 
-val take_while : p:(char -> bool) -> string -> string
-(** [take_while ~p s] keeps only the longest prefix [t] of [s] such that every
-    character [c] in [t] satisfies [p c].
+val take_while : f:(char -> bool) -> string -> string
+(** [take_while ~f s] keeps only the longest prefix [t] of [s] such that every
+    character [c] in [t] satisfies [f c].
     @since 3.16 *)
 
-val rtake_while : p:(char -> bool) -> string -> string
-(** [rtake_while ~p s] keeps only the longest suffix [t] of [s] such that every
-    character [c] in [t] satisfies [p c].
+val rtake_while : f:(char -> bool) -> string -> string
+(** [rtake_while ~f s] keeps only the longest suffix [t] of [s] such that every
+    character [c] in [t] satisfies [f c].
     @since 3.16 *)
 
 val drop : int -> string -> string

--- a/src/core/CCStringLabels.mli
+++ b/src/core/CCStringLabels.mli
@@ -193,6 +193,16 @@ val take : int -> string -> string
 (** [take n s] keeps only the [n] first chars of [s].
     @since 0.17 *)
 
+val take_while : p:(char -> bool) -> string -> string
+(** [take_while ~p s] keeps only the longest prefix [t] of [s] such that every
+    character [c] in [t] satisfies [p c].
+    @since 3.16 *)
+
+val rtake_while : p:(char -> bool) -> string -> string
+(** [rtake_while ~p s] keeps only the longest suffix [t] of [s] such that every
+    character [c] in [t] satisfies [p c].
+    @since 3.16 *)
+
 val drop : int -> string -> string
 (** [drop n s] removes the [n] first chars of [s].
     @since 0.17 *)

--- a/tests/core/t_string.ml
+++ b/tests/core/t_string.ml
@@ -280,18 +280,23 @@ eq ~printer:CCFun.id "" (unlines []);;
 eq ~printer:CCFun.id "ab\nc\n" (unlines [ "ab"; "c" ]);;
 q Q.printable_string (fun s -> trim (unlines (lines s)) = trim s);;
 q Q.printable_string (fun s -> trim (unlines_gen (lines_gen s)) = trim s);;
-
 eq ~printer:CCFun.id "" (take_while (Char.equal 'c') "heloo_cc");;
 eq ~printer:CCFun.id "" (take_while (Char.equal 'c') "");;
 eq ~printer:CCFun.id "c" (take_while (Char.equal 'c') "c");;
 eq ~printer:CCFun.id "ccc" (take_while (Char.equal 'c') "cccujsuy");;
-eq ~printer:CCFun.id "THIS" (take_while (fun c -> Char.code c < 91) "THISisNotWHAtIwANTED");;
+
+eq ~printer:CCFun.id "THIS"
+  (take_while (fun c -> Char.code c < 91) "THISisNotWHAtIwANTED")
+;;
 
 eq ~printer:CCFun.id "cc" (rtake_while (Char.equal 'c') "heloo_cc");;
 eq ~printer:CCFun.id "" (rtake_while (Char.equal 'c') "");;
 eq ~printer:CCFun.id "c" (rtake_while (Char.equal 'c') "c");;
 eq ~printer:CCFun.id "" (rtake_while (Char.equal 'c') "cccujsuy");;
-eq ~printer:CCFun.id "ANTED" (rtake_while (fun c -> Char.code c < 91) "THISisNotWHAtIwANTED");;
+
+eq ~printer:CCFun.id "ANTED"
+  (rtake_while (fun c -> Char.code c < 91) "THISisNotWHAtIwANTED")
+;;
 
 q
   Q.(small_list small_string)

--- a/tests/core/t_string.ml
+++ b/tests/core/t_string.ml
@@ -281,6 +281,18 @@ eq ~printer:CCFun.id "ab\nc\n" (unlines [ "ab"; "c" ]);;
 q Q.printable_string (fun s -> trim (unlines (lines s)) = trim s);;
 q Q.printable_string (fun s -> trim (unlines_gen (lines_gen s)) = trim s);;
 
+eq ~printer:CCFun.id "" (take_while (Char.equal 'c') "heloo_cc");;
+eq ~printer:CCFun.id "" (take_while (Char.equal 'c') "");;
+eq ~printer:CCFun.id "c" (take_while (Char.equal 'c') "c");;
+eq ~printer:CCFun.id "ccc" (take_while (Char.equal 'c') "cccujsuy");;
+eq ~printer:CCFun.id "THIS" (take_while (fun c -> Char.code c < 91) "THISisNotWHAtIwANTED");;
+
+eq ~printer:CCFun.id "cc" (rtake_while (Char.equal 'c') "heloo_cc");;
+eq ~printer:CCFun.id "" (rtake_while (Char.equal 'c') "");;
+eq ~printer:CCFun.id "c" (rtake_while (Char.equal 'c') "c");;
+eq ~printer:CCFun.id "" (rtake_while (Char.equal 'c') "cccujsuy");;
+eq ~printer:CCFun.id "ANTED" (rtake_while (fun c -> Char.code c < 91) "THISisNotWHAtIwANTED");;
+
 q
   Q.(small_list small_string)
   (fun l ->


### PR DESCRIPTION
If you're open to it, I implemented a couple of apparently-missing functions in the `CCString` module, added corresponding tests, and updated `CCString.mli` and `CCStringLabels.mli` accordingly.