### PR TITLE
Additional functions for the `Char` module to check common character properties

### DIFF
--- a/src/core/CCChar.ml
+++ b/src/core/CCChar.ml
@@ -23,3 +23,12 @@ module Infix = struct
 end
 
 include Infix
+
+let is_uppercase_ascii c = c > '\064' && c < '\091'
+let is_lowercase_ascii c = c > '\096' && c < '\123'
+
+let is_letter_ascii c =
+  (is_lowercase_ascii [@inlined]) c || (is_uppercase_ascii [@inlined]) c
+
+let is_digit_ascii c = c > '\047' && c < '\058'
+let is_whitespace_ascii c = c = '\032' || (c > '\008' && c < '\014')

--- a/src/core/CCChar.mli
+++ b/src/core/CCChar.mli
@@ -47,7 +47,7 @@ val is_uppercase_ascii : t -> bool
 
 val is_lowercase_ascii : t -> bool
 (** [is_lowercase_ascii c] is true exactly when [c] is a
-    lowercase ASCII character, i.e. ['\097'] < [c] < ['\123'].
+    lowercase ASCII character, i.e. ['\096'] < [c] < ['\123'].
     @since 3.16 *)
 
 val is_letter_ascii : t -> bool

--- a/src/core/CCChar.mli
+++ b/src/core/CCChar.mli
@@ -40,6 +40,32 @@ val pp_buf : Buffer.t -> t -> unit
 val pp : Format.formatter -> t -> unit
 (** Renamed from [print] since 2.0. *)
 
+val is_uppercase_ascii : t -> bool
+(** [is_uppercase_ascii c] is true exactly when  [c] is an
+    uppercase ASCII character, i.e. ['\064'] < [c] < ['\091'].
+    @since 3.16 *)
+
+val is_lowercase_ascii : t -> bool
+(** [is_lowercase_ascii c] is true exactly when [c] is a
+    lowercase ASCII character, i.e. ['\097'] < [c] < ['\123'].
+    @since 3.16 *)
+
+val is_letter_ascii : t -> bool
+(** [is_letter_ascii c] is true exactly when [c] is an ASCII
+    letter, i.e. [is_uppercase_ascii c || is_lowercase_ascii c].
+    @since 3.16 *)
+
+val is_digit_ascii : t -> bool
+(** [is_digit_ascii c] is true exactly when [c] is an
+    ASCII digit, i.e. ['\047'] < [c] < ['\058'].
+    @since 3.16 *)
+
+val is_whitespace_ascii : t -> bool
+(** [is_whitespace_ascii c] is true exactly when [c] is an ASCII
+    whitespace character as defined by Unicode, i.e. either [c = ' ']
+    or ['\008'] < [c] < ['\014'].
+    @since 3.16 *)
+
 (** {2 Infix Operators}
 
     @since 3.3 *)

--- a/tests/core/t_char.ml
+++ b/tests/core/t_char.ml
@@ -43,8 +43,41 @@ q
   (fun c -> not @@ CCChar.is_digit_ascii c)
 ;;
 
-eq true (String.for_all CCChar.is_whitespace_ascii "\n\t \010\011\012\013");;
+eq true
+  (Stdlib.List.for_all CCChar.is_whitespace_ascii
+     [ '\n'; '\t'; ' '; '\010'; '\011'; '\012'; '\013' ])
+;;
 
 eq false
-  (String.for_all CCChar.is_whitespace_ascii
-     "Hello!--NOthina\055kag$$$%^bch\008h")
+  (Stdlib.List.exists CCChar.is_whitespace_ascii
+     [
+       'H';
+       'e';
+       'l';
+       'l';
+       'o';
+       '!';
+       '-';
+       '-';
+       'N';
+       'O';
+       't';
+       'h';
+       'i';
+       'n';
+       'a';
+       '\055';
+       'k';
+       'a';
+       'g';
+       '$';
+       '$';
+       '$';
+       '%';
+       '^';
+       'b';
+       'c';
+       'h';
+       '\008';
+       'h';
+     ])

--- a/tests/core/t_char.ml
+++ b/tests/core/t_char.ml
@@ -8,3 +8,43 @@ eq None (of_int 257);;
 q
   (Q.string_of_size (Q.Gen.return 1))
   (fun s -> Stdlib.( = ) (to_string s.[0]) s)
+;;
+
+q (Q.int_range 65 90 |> Q.map Char.chr) CCChar.is_uppercase_ascii;;
+
+q
+  (Q.int_range 0 64 |> Q.map Char.chr)
+  (fun c -> not @@ CCChar.is_uppercase_ascii c)
+;;
+
+q
+  (Q.int_range 91 127 |> Q.map Char.chr)
+  (fun c -> not @@ CCChar.is_uppercase_ascii c)
+;;
+
+q (Q.int_range 97 122 |> Q.map Char.chr) CCChar.is_lowercase_ascii;;
+
+q
+  (Q.int_range 0 96 |> Q.map Char.chr)
+  (fun c -> not @@ CCChar.is_lowercase_ascii c)
+;;
+
+q
+  (Q.int_range 123 127 |> Q.map Char.chr)
+  (fun c -> not @@ CCChar.is_lowercase_ascii c)
+;;
+
+q (Q.int_range 48 57 |> Q.map Char.chr) CCChar.is_digit_ascii;;
+q (Q.int_range 0 47 |> Q.map Char.chr) (fun c -> not @@ CCChar.is_digit_ascii c)
+;;
+
+q
+  (Q.int_range 58 127 |> Q.map Char.chr)
+  (fun c -> not @@ CCChar.is_digit_ascii c)
+;;
+
+eq true (String.for_all CCChar.is_whitespace_ascii "\n\t \010\011\012\013");;
+
+eq false
+  (String.for_all CCChar.is_whitespace_ascii
+     "Hello!--NOthina\055kag$$$%^bch\008h")


### PR DESCRIPTION
I've added some functions to check whether a given character is uppercase, lowercase, a letter, a digit, or white-space, respectively. These are particularly useful in building predicates for `CCString` functions like `contains`, `exists`, &c. Let me know what you think, and if you want any changes.

The names align with the convention set by Stdlib's `Char` of indicating the character encoding nominally.