### PR TITLE
Add OCaml 5.4 support

### DIFF
--- a/src/core/CCArray.ml
+++ b/src/core/CCArray.ml
@@ -93,7 +93,7 @@ let sort_indices cmp a =
   Array.sort (fun k1 k2 -> cmp a.(k1) a.(k2)) b;
   b
 
-let sort_ranking cmp a = sort_indices compare (sort_indices cmp a)
+let sort_ranking cmp a = sort_indices Int.compare (sort_indices cmp a)
 
 let rev a =
   let b = Array.copy a in


### PR DESCRIPTION
OCaml 5.4 added `Array.compare`, which now shadows `Stdlib.compare` previously used in `sort_ranking` and caused the following error:
```
#=== ERROR while compiling containers.3.15 ====================================#
# context     2.4.0~alpha2 | linux/x86_64 | ocaml-base-compiler.5.4.0~alpha1 | https://opam.ocaml.org#584630e7a7e27e3cf56158696a3fe94623a0cf4f
# path        ~/.opam/default/.opam-switch/build/containers.3.15
# command     ~/.opam/opam-init/hooks/sandbox.sh build dune build -p containers -j 31  
# exit-code   1
# env-file    ~/.opam/log/containers-798-8d26f9.env
# output-file ~/.opam/log/containers-798-8d26f9.out
### output ###
# Error: The value compare has type                  
# [...]                                                                                                    
#          ('a -> 'a -> int) -> ('a -> 'a -> int) -> int                                                   
#        Type 'a array is not compatible with type 'a -> 'a -> int                                         
# (cd _build/default && /home/opam-health-check/.opam/default/bin/ocamlopt.opt -w -40 -warn-error -a+8 -w -32-48-60-70 -w +a-4-40-42-44-70 -color always -safe-string -strict-sequence -nolabels -open CCMonomorphic -g -O3 -unbox-closures -unbox-closures-factor 20 -inline 100 -I src/core/.containers.objs/byte -I src/core/.containers.objs/native -I /home/opam-health-check/.opam/default/lib/either -[...]                          
# File "src/core/CCArray.pp.ml", line 96, characters 38-45:                                                
# 96 | let sort_ranking cmp a = sort_indices compare (sort_indices cmp a)                                  
#                                            ^^^^^^^                                                       
# Error: The value compare has type                                                                        
#          ('a -> 'a -> int) -> 'a array -> 'a array -> int               
#        but an expression was expected of type
#          ('a -> 'a -> int) -> ('a -> 'a -> int) -> int                                                   
#        Type 'a array is not compatible with type 'a -> 'a -> int                                   
```
This PR fixes that issue and makes it able to compile containers with OCaml 5.4