### PR TITLE
Patch CBor round-trip QCheck test to hold for nan's too

### DIFF
--- a/tests/core/t_cbor.ml
+++ b/tests/core/t_cbor.ml
@@ -99,11 +99,11 @@ let rec shrink (c : Cbor.t) : Cbor.t Q.Iter.t =
     let+ s = Q.Shrink.string s in
     `Bytes s
 
-let arb = Q.make ~shrink ~print:Cbor.to_string_diagnostic gen_c;;
+let arb = Q.make ~shrink ~print:Cbor.to_string_diagnostic gen_c
 
-let rec eq_c c c' = match c,c' with
-  | `Null, `Null
-  | `Undefined, `Undefined -> true
+let rec eq_c c c' =
+  match c, c' with
+  | `Null, `Null | `Undefined, `Undefined -> true
   | `Simple i, `Simple i' -> Int.equal i i'
   | `Bool b, `Bool b' -> Bool.equal b b'
   | `Int i, `Int i' -> Int64.equal i i'
@@ -112,9 +112,10 @@ let rec eq_c c c' = match c,c' with
   | `Text t, `Text t' -> String.equal t t'
   | `Array a, `Array a' -> CCList.equal eq_c a a'
   | `Map m, `Map m' ->
-    CCList.equal (fun (t0,t1) (t0',t1') -> eq_c t0 t0' && eq_c t1 t1') m m'
-  | `Tag (i,t), `Tag (i',t') -> Int.equal i i' && eq_c t t'
-  | _ -> false;;
+    CCList.equal (fun (t0, t1) (t0', t1') -> eq_c t0 t0' && eq_c t1 t1') m m'
+  | `Tag (i, t), `Tag (i', t') -> Int.equal i i' && eq_c t t'
+  | _ -> false
+;;
 
 q ~count:1_000 ~long_factor:10 arb @@ fun c ->
 let s = Cbor.encode c in


### PR DESCRIPTION
The forthcoming QCheck 0.26 release https://github.com/ocaml/opam-repository/pull/28148 changes the distribution of the `float` generator to avoid blind spots: https://github.com/c-cube/qcheck/pull/350

As a consequence, the existing round-trip property-based test for CBor now fails to hold, as `nan = nan` doesn't hold, resulting in, e.g.:
```
File "tests/core/dune", line 2, characters 7-8:
2 |  (name t)
           ^
seed: 9590b92181c82cc2
testing containers: running 1219 tests…
FAILED: (test :file 'tests/core/t_cbor.pp.ml' :n 0)
1219 tests done in 4.880s
ERROR (1 failures)

========
failed (test :file 'tests/core/t_cbor.pp.ml' :n 0):
failed on instances:
  `{-nan: ""}` (after 25 shrink steps)
roundtrip failed: from {-nan: ""} to {-nan: ""}
```

This PR patches the round-trip property with a recursively defined equality predicate, falling back on `Float.equal` to compare `nan`s (which has the desired behaviour).