### PR TITLE
fix: insert missing symbol into range doc comments

### DIFF
--- a/src/core/CCSeq.mli
+++ b/src/core/CCSeq.mli
@@ -183,7 +183,7 @@ val ( -- ) : int -> int -> int t
     [a] and [b] (therefore, never empty). *)
 
 val ( --^ ) : int -> int -> int t
-(** [a -- b] is the integer range from [a] to [b], where [b] is excluded. *)
+(** [a --^ b] is the integer range from [a] to [b], where [b] is excluded. *)
 
 (** {2 Operations on two Collections} *)
 

--- a/src/data/CCFQueue.mli
+++ b/src/data/CCFQueue.mli
@@ -139,7 +139,7 @@ val ( -- ) : int -> int -> int t
     @since 0.10 *)
 
 val ( --^ ) : int -> int -> int t
-(** [a -- b] is the integer range from [a] to [b], where [b] is excluded.
+(** [a --^ b] is the integer range from [a] to [b], where [b] is excluded.
     @since 0.17 *)
 
 val pp : 'a printer -> 'a t printer


### PR DESCRIPTION
The `^` character was missing from the exclusive range operator in two places.